### PR TITLE
fix permission detection

### DIFF
--- a/root/etc/cont-init.d/40-plex-first-run
+++ b/root/etc/cont-init.d/40-plex-first-run
@@ -50,7 +50,7 @@ fi
 # Update ownership of dirs we need to write
 if [ "${CHANGE_CONFIG_DIR_OWNERSHIP,,}" = "true" ]; then
   if [ -f "${prefFile}" ]; then
-    if [ ! "$(stat -c %U "${prefFile}")" = "plex" ]; then
+    if [ ! "$(stat -c %u "${prefFile}")" = "${PLEX_UID}" ]; then
       chown -R plex:plex /config
     fi
   else

--- a/root/etc/cont-init.d/40-plex-first-run
+++ b/root/etc/cont-init.d/40-plex-first-run
@@ -50,7 +50,7 @@ fi
 # Update ownership of dirs we need to write
 if [ "${CHANGE_CONFIG_DIR_OWNERSHIP,,}" = "true" ]; then
   if [ -f "${prefFile}" ]; then
-    if [ ! "$(stat -c %u "${prefFile}")" = "${PLEX_UID}" ]; then
+    if [ ! "$(stat -c %u "${prefFile}")" = "$(id -u plex)" ]; then
       chown -R plex:plex /config
     fi
   else


### PR DESCRIPTION
If PLEX_UID is set to an existing user's uid, like 0 (root), then `stat -c %U` returns "root" instead of "plex" and forces an unnecessary `chown -R`. Instead using `stat -c %u` and checking it against the PLEX_UID is more accurate and prevents unnecessary chowns.