### PR TITLE
Add healthcheck using web UI

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,3 +50,6 @@ COPY root/ /
 RUN \
 # Save version and install
     /installBinary.sh
+
+HEALTHCHECK --interval=200s --timeout=100s CMD /healthcheck.sh || exit 1
+

--- a/root/healthcheck.sh
+++ b/root/healthcheck.sh
@@ -1,0 +1,7 @@
+#!/bin/sh -e
+
+TARGET=localhost
+CURL_OPTS="--connect-timeout 15 --silent --show-error --fail"
+
+curl ${CURL_OPTS} "http://${TARGET}:32400/web/index.html" >/dev/null
+

--- a/root/healthcheck.sh
+++ b/root/healthcheck.sh
@@ -3,5 +3,5 @@
 TARGET=localhost
 CURL_OPTS="--connect-timeout 15 --silent --show-error --fail"
 
-curl ${CURL_OPTS} "http://${TARGET}:32400/web/index.html" >/dev/null
+curl ${CURL_OPTS} "http://${TARGET}:32400/identity" >/dev/null
 


### PR DESCRIPTION
Docker 1.12 added the ability to specify a health check via the HEALTHCHECK instruction. Docker 1.12 is required to build with the HEALTHCHECK instruction, but older versions of docker can run the image, the health check information is ignored.

This PR adds a health check based on http://localhost:32400/web/index.html returning a successful status code.

Is there a better URL for status? Multiple URLs for different services?