### PR TITLE
Fix `docker run --network` parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ For those who use docker-compose, this repository provides the necessary YML tem
 docker run \
 -d \
 --name plex \
---net=host \
+--network=host \
 -e TZ="<timezone>" \
 -e PLEX_CLAIM="<claimToken>" \
 -v <path/to/plex/database>:/config \
@@ -39,7 +39,7 @@ plexinc/pms-docker
 docker run \
 -d \
 --name plex \
---net=physical \
+--network=physical \
 --ip=<IPAddress> \
 -e TZ="<timezone>" \
 -e PLEX_CLAIM="<claimToken>" \


### PR DESCRIPTION
The `docker run` scripts in the `README` point to a `--net=`
configuration parameter whereas the Docker Run documentation
(https://docs.docker.com/engine/reference/run/) calls the
configuration variable `--network`. Update the `README` to
reflect the correct configuration parameter name.

---

I am very new to Docker and this is my first time trying to run a Docker image on a server. When trying to set up Plex Media Server using the **Host Networking** instructions, it did not work. However, once I changed `--net` to `--network`, everything started working as expected. Hence, I'm pretty sure that there is a typo in the `README`. If so, this PR should fix that problem.