### PR TITLE
Ensures 'tzdata' package is installed.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ RUN \
 # Update and get dependencies
     apt-get update && \
     apt-get install -y \
+      tzdata \
       curl \
       xmlstarlet \
       uuid-runtime \


### PR DESCRIPTION
This package is necessary in order to provide zoneinfo and support
for using the TZ environment variable.