### PR TITLE
Advice for known issues with headless server setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,3 +159,10 @@ plex    | s6-supervise (child): fatal: unable to exec run: Permission denied
 plex    | s6-supervise avahi: warning: unable to spawn ./run - waiting 10 seconds
 ```
 As a workaround you can add `- /run` to volumes in your docker-compose.yml or `-v /run` to the docker create command.
+
+## Running on a headless server
+
+When you first login to the PMS, you will need to setup the server to make it available and configurable. However, this setup option will only be triggered if you access it over http://localhost:32400/web, it will not be triggered if you access it over http://ip_of_server:32400/web. If you are setting up PMS on a headless server, you can use a SSH tunnel to link http://localhost:32400/web (on your current computer) to http://localhost:32400/web (on the headless server running PMS):
+
+`ssh username@ip_of_server -L 32400:ip_of_server:32400 -N`
+


### PR DESCRIPTION
If you try to access http://ip_of_server:32400/web, the server will not be found. It can only be "found" (and subsequently setup) by accessing it from http://localhost:32400/web. A SSH tunnel removes the need to plug your headless server into a monitor+keyboard+mouse.