### PR TITLE
Fix mising udev in plexpass tag

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,7 @@ RUN \
       curl \
       xmlstarlet \
       uuid-runtime \
+      udev \
     && \
 
 # Fetch and extract S6 overlay


### PR DESCRIPTION
During startup, `plexpass` image shows the following warning:

```
Setting up plexmediaserver (1.9.5.4339-46276db8d) ...

##################################################################
#  NOTE: Your system does not have udev installed. Without udev  #
#        you won't be able to use DVBLogic's TVButler for DVR    #
#        or for LiveTV                                           #
#                                                                #
#        Please install udev and reinstall Plex Media Server to  #
#        to enable TV Butler support in Plex Media Server.       #
#                                                                #
#        To install udev run: sudo apt-get install udev          #
#                                                                #
##################################################################
```