### PR TITLE
Resetting ownership of mounted paths at restart

### DIFF
--- a/root/etc/cont-init.d/50-plex-update
+++ b/root/etc/cont-init.d/50-plex-update
@@ -7,6 +7,9 @@ fi
 
 . /plex-common.sh
 
+# Ensure proper transcode directory ownership
+chown -R plex:plex /transcode
+
 function getPref {
   local key="$1"
 
@@ -54,15 +57,3 @@ fi
 # Do update process
 echo "Attempting to upgrade to: ${remoteVersion}"
 installFromUrl "${remoteFile}"
-
-# Update ownership of dirs we need to write
-if [ "${CHANGE_CONFIG_DIR_OWNERSHIP,,}" = "true" ]; then
-  if [ -f "${prefFile}" ]; then
-    if [ ! "$(stat -c %u "${prefFile}")" = "$(id -u plex)" ]; then
-      chown -R plex:plex /config
-    fi
-  else
-    chown -R plex:plex /config
-  fi
-  chown -R plex:plex /transcode
-fi

--- a/root/etc/cont-init.d/50-plex-update
+++ b/root/etc/cont-init.d/50-plex-update
@@ -54,3 +54,15 @@ fi
 # Do update process
 echo "Attempting to upgrade to: ${remoteVersion}"
 installFromUrl "${remoteFile}"
+
+# Update ownership of dirs we need to write
+if [ "${CHANGE_CONFIG_DIR_OWNERSHIP,,}" = "true" ]; then
+  if [ -f "${prefFile}" ]; then
+    if [ ! "$(stat -c %u "${prefFile}")" = "$(id -u plex)" ]; then
+      chown -R plex:plex /config
+    fi
+  else
+    chown -R plex:plex /config
+  fi
+  chown -R plex:plex /transcode
+fi


### PR DESCRIPTION
There are cases when the ownership of the transcode dir is reset to root when starting the container. This fix runs the logic to fix the ownership of /config and /transcode at every restart.