### PR TITLE
Add unrar

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,7 @@ RUN \
       curl \
       xmlstarlet \
       uuid-runtime \
+      unrar \
     && \
 
 # Fetch and extract S6 overlay


### PR DESCRIPTION
Unrar is needed for SubZero to download subs.