### PR TITLE
Fix for broken PMS startup after update to 1.15.0.659-9311f93fd

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,23 +15,20 @@ RUN \
       xmlstarlet \
       uuid-runtime \
       unrar \
+      libva1 \
     && \
-
 # Fetch and extract S6 overlay
     curl -J -L -o /tmp/s6-overlay-amd64.tar.gz https://github.com/just-containers/s6-overlay/releases/download/${S6_OVERLAY_VERSION}/s6-overlay-amd64.tar.gz && \
     tar xzf /tmp/s6-overlay-amd64.tar.gz -C / && \
-
 # Add user
     useradd -U -d /config -s /bin/false plex && \
     usermod -G users plex && \
-
 # Setup directories
     mkdir -p \
       /config \
       /transcode \
       /data \
     && \
-
 # Cleanup
     apt-get -y autoremove && \
     apt-get -y clean && \


### PR DESCRIPTION
* Added libva1 to installed libraries. Fixes broken pms startup. Otherwise you see a lot of the following during the startup attempts:
```plex        | Starting Plex Media Server.
plex        | /usr/lib/plexmediaserver/Plex Media Server: error while loading shared libraries: libva.so.2: cannot open shared object file: No such file or directory
plex        | Starting Plex Media Server.
plex        | /usr/lib/plexmediaserver/Plex Media Server: error while loading shared libraries: libva.so.2: cannot open shared object file: No such file or directory
plex        | Starting Plex Media Server.
plex        | /usr/lib/plexmediaserver/Plex Media Server: error while loading shared libraries: libva.so.2: cannot open shared object file: No such file or directory
plex        | Starting Plex Media Server.
plex        | /usr/lib/plexmediaserver/Plex Media Server: error while loading shared libraries: libva.so.2: cannot open shared object file: No such file or directory
```

* Removed blank lines from Dockerfile that were generating warnings during docker build process. Related to deprecation of functionality in Docker. 
