### PR TITLE
Also check connected tuners for video group.

### DIFF
--- a/root/etc/cont-init.d/45-plex-hw-transcode-and-connected-tuner
+++ b/root/etc/cont-init.d/45-plex-hw-transcode-and-connected-tuner
@@ -1,12 +1,18 @@
 #!/usr/bin/with-contenv bash
 
-# Check to make sure the device exists.  If it doesn't exit as there is nothing for us to do
-if [ ! -e /dev/dri ]; then
+# Check to make sure the devices exists.  If not, exit as there is nothing for us to do
+if [ ! -e /dev/dri ] && [ ! -e /dev/dvb ]; then
 	exit 0
 fi
 
-# Get the group IDs for the dri devices and the video group
-DEVICE_GID=$(stat -c '%g' /dev/dri/* | grep -v '^0$' | head -n 1)
+# Get the group ID for the dri or dvb devices.
+if [ -e /dev/dri ]; then
+  DEVICE_GID=$(stat -c '%g' /dev/dri/* | grep -v '^0$' | head -n 1)
+else
+  DEVICE_GID=$(stat -c '%g' /dev/dvb/adapter*/* | grep -v '^0$' | head -n 1)
+fi
+
+# Get the group ID for the video group
 VIDEO_GID=$(getent group video | awk -F: '{print $3}')
 
 # If the video group's ID matches the group ID of the device, exit as permissions are already setup.


### PR DESCRIPTION
Discussion came up in #41.  We should check dvb devices for permissions as well.

@Sparticuz, can you check these changes to see if this works for you?  I don't have the hardware to test with.  Likely best tested without the dri devices passed into the container.