### PR TITLE
Remove extraneous 'be' in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ The following are the recommended parameters.  Each of the following parameters 
 - **HOSTNAME** Sets the hostname inside the docker container. For example `-h PlexServer` will set the servername to `PlexServer`.  Not needed in Host Networking.
 - **TZ** Set the timezone inside the container.  For example: `Europe/London`.  The complete list can be found here: [https://en.wikipedia.org/wiki/List_of_tz_database_time_zones](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones)
 - **PLEX_CLAIM** The claim token for the server to obtain a real server token.  If not provided, server will not be automatically logged in.  If server is already logged in, this parameter is ignored.  You can obtain a claim token to login your server to your plex account by visiting [https://www.plex.tv/claim](https://www.plex.tv/claim)
-- **ADVERTISE_IP** This variable defines the additional IPs on which the server may be be found.  For example: `http://10.1.1.23:32400`.  This adds to the list where the server advertises that it can be found.  This is only needed in Bridge Networking.
+- **ADVERTISE_IP** This variable defines the additional IPs on which the server may be found.  For example: `http://10.1.1.23:32400`.  This adds to the list where the server advertises that it can be found.  This is only needed in Bridge Networking.
 
 These parameters are usually not required but some special setups may benefit from their use.  As in the previous section, each is treated as first-run parameters only:
 


### PR DESCRIPTION
The README instructions for 'ADVERTISE_IP' had an extra word `be` that needed to be removed. This commit removes it.  :)