### PR TITLE
Update to cater for multiple video device groups.

### DIFF
--- a/root/etc/cont-init.d/45-plex-hw-transcode-and-connected-tuner
+++ b/root/etc/cont-init.d/45-plex-hw-transcode-and-connected-tuner
@@ -5,28 +5,23 @@ if [ ! -e /dev/dri ] && [ ! -e /dev/dvb ]; then
 	exit 0
 fi
 
-# Get the group ID for the dri or dvb devices.
-if [ -e /dev/dri ]; then
-  DEVICE_GID=$(stat -c '%g' /dev/dri/* | grep -v '^0$' | head -n 1)
-else
-  DEVICE_GID=$(stat -c '%g' /dev/dvb/adapter*/* | grep -v '^0$' | head -n 1)
-fi
+FILES=$(find /dev/dri /dev/dvb -type c -print 2>/dev/null)
 
-# Get the group ID for the video group
-VIDEO_GID=$(getent group video | awk -F: '{print $3}')
+for i in $FILES
+do
+# Get the group ID for the dri or dvb device.
+    DEVICE_GID=$(stat -c '%g' $i)
+# Get the group name (if it exists)
+    CURRENT_GROUP=$(getent group "${DEVICE_GID}" | awk -F: '{print $1}')
+# If it doesn't exist, create a new group name and assign it to the device GID
+    if [ -z "${CURRENT_GROUP}" ]; then
+	CURRENT_GROUP=video$(head /dev/urandom | tr -dc 'a-zA-Z0-9' | head -c4)
+	groupadd "${CURRENT_GROUP}"
+	groupmod -g "${DEVICE_GID}" "${CURRENT_GROUP}"
+    fi
+# If plex user isn't part of this group, add them
+    if [ ! $(getent group "${CURRENT_GROUP}" | grep &>/dev/null plex) ]; then
+	usermod -a -G "${CURRENT_GROUP}" plex
+    fi
+done
 
-# If the video group's ID matches the group ID of the device, exit as permissions are already setup.
-if [ "${DEVICE_GID}" == "${VIDEO_GID}" ]; then
-	exit 0
-fi
-
-# Get the current group name for the device's group ID
-CURRENT_GROUP=$(getent group ${DEVICE_GID} | awk -F: '{print $1}')
-
-if [ -z "${CURRENT_GROUP}" ]; then
-	# If there is no group name for the device's group ID, change the video group to that ID.
-	groupmod -g ${DEVICE_GID} video
-else
-	# There is a group name, so add it to the plex user's list of groups
-	usermod -a -G ${CURRENT_GROUP} plex
-fi

--- a/root/etc/cont-init.d/45-plex-hw-transcode-and-connected-tuner
+++ b/root/etc/cont-init.d/45-plex-hw-transcode-and-connected-tuner
@@ -6,22 +6,23 @@ if [ ! -e /dev/dri ] && [ ! -e /dev/dvb ]; then
 fi
 
 FILES=$(find /dev/dri /dev/dvb -type c -print 2>/dev/null)
+GROUP_COUNT=1
 
 for i in $FILES
 do
-# Get the group ID for the dri or dvb device.
-    DEVICE_GID=$(stat -c '%g' $i)
-# Get the group name (if it exists)
+    # Get the group ID for the dri or dvb device.
+    DEVICE_GID=$(stat -c '%g' "$i")
+    # Get the group name (if it exists)
     CURRENT_GROUP=$(getent group "${DEVICE_GID}" | awk -F: '{print $1}')
-# If it doesn't exist, create a new group name and assign it to the device GID
+    # If it doesn't exist, create a new group name and assign it to the device GID
     if [ -z "${CURRENT_GROUP}" ]; then
-	CURRENT_GROUP=video$(head /dev/urandom | tr -dc 'a-zA-Z0-9' | head -c4)
-	groupadd "${CURRENT_GROUP}"
-	groupmod -g "${DEVICE_GID}" "${CURRENT_GROUP}"
+	CURRENT_GROUP=video${GROUP_COUNT}
+	groupadd -g "${DEVICE_GID}" "${CURRENT_GROUP}"
     fi
-# If plex user isn't part of this group, add them
+    # If plex user isn't part of this group, add them
     if [ ! $(getent group "${CURRENT_GROUP}" | grep &>/dev/null plex) ]; then
 	usermod -a -G "${CURRENT_GROUP}" plex
     fi
+    GROUP_COUNT=$(($GROUP_COUNT + 1))
 done
 


### PR DESCRIPTION
This change caters to situations where there are multiple different groups for video devices.  For example on my system there is:
/dev/dri/card0 with group video
/dev/dri/renderD128 with group render

Current script doesn't take this into account and misses the render device, causing HW transcoding not to work correctly.