### PR TITLE
Add arm64 support and Update Plex Download URLs to latest API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 docker-compose.yml
+
+test/

--- a/Dockerfile
+++ b/Dockerfile
@@ -49,7 +49,7 @@ VOLUME /config /transcode
 ENV CHANGE_CONFIG_DIR_OWNERSHIP="true" \
     HOME="/config"
 
-ARG TAG=public
+ARG TAG=beta
 ARG URL=
 
 COPY root/ /

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,6 @@ RUN \
       xmlstarlet \
       uuid-runtime \
       unrar \
-      udev \
     && \
 
 # Fetch and extract S6 overlay

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,9 @@
 FROM ubuntu:16.04
 
-ARG S6_OVERLAY_VERSION=v1.17.2.0
+ARG S6_OVERLAY_VERSION=v1.22.1.0
+ARG S6_OVERLAY_ARCH=amd64
+ARG PLEX_BUILD=linux-x86_64
+ARG PLEX_DISTRO=debian
 ARG DEBIAN_FRONTEND="noninteractive"
 ENV TERM="xterm" LANG="C.UTF-8" LC_ALL="C.UTF-8"
 
@@ -15,11 +18,12 @@ RUN \
       xmlstarlet \
       uuid-runtime \
       unrar \
+      udev \
     && \
 
 # Fetch and extract S6 overlay
-    curl -J -L -o /tmp/s6-overlay-amd64.tar.gz https://github.com/just-containers/s6-overlay/releases/download/${S6_OVERLAY_VERSION}/s6-overlay-amd64.tar.gz && \
-    tar xzf /tmp/s6-overlay-amd64.tar.gz -C / && \
+    curl -J -L -o /tmp/s6-overlay-${S6_OVERLAY_ARCH}.tar.gz https://github.com/just-containers/s6-overlay/releases/download/${S6_OVERLAY_VERSION}/s6-overlay-${S6_OVERLAY_ARCH}.tar.gz && \
+    tar xzf /tmp/s6-overlay-${S6_OVERLAY_ARCH}.tar.gz -C / && \
 
 # Add user
     useradd -U -d /config -s /bin/false plex && \
@@ -45,7 +49,7 @@ VOLUME /config /transcode
 ENV CHANGE_CONFIG_DIR_OWNERSHIP="true" \
     HOME="/config"
 
-ARG TAG=beta
+ARG TAG=public
 ARG URL=
 
 COPY root/ /

--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -49,7 +49,7 @@ VOLUME /config /transcode
 ENV CHANGE_CONFIG_DIR_OWNERSHIP="true" \
     HOME="/config"
 
-ARG TAG=public
+ARG TAG=beta
 ARG URL=
 
 COPY root/ /

--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -18,7 +18,6 @@ RUN \
       xmlstarlet \
       uuid-runtime \
       unrar \
-      udev \
     && \
 
 # Fetch and extract S6 overlay

--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -1,0 +1,61 @@
+FROM ubuntu:16.04
+
+ARG S6_OVERLAY_VERSION=v1.22.1.0
+ARG S6_OVERLAY_ARCH=aarch64
+ARG PLEX_BUILD=linux-aarch64
+ARG PLEX_DISTRO=debian
+ARG DEBIAN_FRONTEND="noninteractive"
+ENV TERM="xterm" LANG="C.UTF-8" LC_ALL="C.UTF-8"
+
+ENTRYPOINT ["/init"]
+
+RUN \
+# Update and get dependencies
+    apt-get update && \
+    apt-get install -y \
+      tzdata \
+      curl \
+      xmlstarlet \
+      uuid-runtime \
+      unrar \
+      udev \
+    && \
+
+# Fetch and extract S6 overlay
+    curl -J -L -o /tmp/s6-overlay-${S6_OVERLAY_ARCH}.tar.gz https://github.com/just-containers/s6-overlay/releases/download/${S6_OVERLAY_VERSION}/s6-overlay-${S6_OVERLAY_ARCH}.tar.gz && \
+    tar xzf /tmp/s6-overlay-${S6_OVERLAY_ARCH}.tar.gz -C / && \
+
+# Add user
+    useradd -U -d /config -s /bin/false plex && \
+    usermod -G users plex && \
+
+# Setup directories
+    mkdir -p \
+      /config \
+      /transcode \
+      /data \
+    && \
+
+# Cleanup
+    apt-get -y autoremove && \
+    apt-get -y clean && \
+    rm -rf /var/lib/apt/lists/* && \
+    rm -rf /tmp/* && \
+    rm -rf /var/tmp/*
+
+EXPOSE 32400/tcp 3005/tcp 8324/tcp 32469/tcp 1900/udp 32410/udp 32412/udp 32413/udp 32414/udp
+VOLUME /config /transcode
+
+ENV CHANGE_CONFIG_DIR_OWNERSHIP="true" \
+    HOME="/config"
+
+ARG TAG=public
+ARG URL=
+
+COPY root/ /
+
+RUN \
+# Save version and install
+    /installBinary.sh
+
+HEALTHCHECK --interval=5s --timeout=2s --retries=20 CMD /healthcheck.sh || exit 1

--- a/root/etc/cont-init.d/50-plex-update
+++ b/root/etc/cont-init.d/50-plex-update
@@ -27,6 +27,7 @@ else
 fi
 
 # Read set version
+## TODO : Read version value from the new file ##
 versionToInstall="$(cat /version.txt)"
 if [ -z "${versionToInstall}" ]; then
   echo "No version specified in install.  Broken image"

--- a/root/etc/cont-init.d/50-plex-update
+++ b/root/etc/cont-init.d/50-plex-update
@@ -27,8 +27,7 @@ else
 fi
 
 # Read set version
-## TODO : Read version value from the new file ##
-versionToInstall="$(cat /version.txt)"
+readVarFromConf "version" versionToInstall
 if [ -z "${versionToInstall}" ]; then
   echo "No version specified in install.  Broken image"
   exit 1

--- a/root/installBinary.sh
+++ b/root/installBinary.sh
@@ -2,6 +2,7 @@
 
 . /plex-common.sh
 
+## TODO : Make a file with these 3 variables ##
 echo "${TAG}" > /version.txt
 echo "${PLEX_BUILD}" > /plex-build.txt
 echo "${PLEX_DISTRO}" > /plex-distro.txt

--- a/root/installBinary.sh
+++ b/root/installBinary.sh
@@ -3,6 +3,8 @@
 . /plex-common.sh
 
 echo "${TAG}" > /version.txt
+echo "${PLEX_BUILD}" > /plex-build.txt
+echo "${PLEX_DISTRO}" > /plex-distro.txt
 if [ ! -z "${URL}" ]; then
   echo "Attempting to install from URL: ${URL}"
   installFromRawUrl "${URL}"

--- a/root/installBinary.sh
+++ b/root/installBinary.sh
@@ -2,10 +2,10 @@
 
 . /plex-common.sh
 
-## TODO : Make a file with these 3 variables ##
-echo "${TAG}" > /version.txt
-echo "${PLEX_BUILD}" > /plex-build.txt
-echo "${PLEX_DISTRO}" > /plex-distro.txt
+addVarToConf "version" "${TAG}"
+addVarToConf "plex_build" "${PLEX_BUILD}"
+addVarToConf "plex_distro" "${PLEX_DISTRO}"
+
 if [ ! -z "${URL}" ]; then
   echo "Attempting to install from URL: ${URL}"
   installFromRawUrl "${URL}"

--- a/root/plex-common.sh
+++ b/root/plex-common.sh
@@ -19,7 +19,9 @@ function getVersionInfo {
     channel=8
   fi
   
-  local url="https://plex.tv/downloads/details/1?build=linux-ubuntu-x86_64&channel=${channel}&distro=ubuntu"
+  local plexBuild="$(cat /plex-build.txt)"
+  local plexDistro="$(cat /plex-distro.txt)"
+  local url="https://plex.tv/downloads/details/5?build=${plexBuild}&channel=${channel}&distro=${plexDistro}"
   if [ ${tokenNeeded} -gt 0 ]; then
     url="${url}&X-Plex-Token=${token}"
   fi

--- a/root/plex-common.sh
+++ b/root/plex-common.sh
@@ -19,6 +19,7 @@ function getVersionInfo {
     channel=8
   fi
   
+  ## TODO : Read values from the new file ##
   local plexBuild="$(cat /plex-build.txt)"
   local plexDistro="$(cat /plex-distro.txt)"
   local url="https://plex.tv/downloads/details/5?build=${plexBuild}&channel=${channel}&distro=${plexDistro}"

--- a/root/plex-common.sh
+++ b/root/plex-common.sh
@@ -1,5 +1,25 @@
 #!/bin/bash
 
+CONT_CONF_FILE="/version.txt"
+
+function addVarToConf {
+  local variable="$1"
+  local value="$2"
+  if [ ! -z "${variable}" ]; then
+    echo ${variable}=${value} >> ${CONT_CONF_FILE}
+  fi
+}
+
+function readVarFromConf {
+  local variable="$1"
+  declare -n value=$2
+  if [ ! -z "${variable}" ]; then
+    value="$(grep -w ${variable} ${CONT_CONF_FILE} | cut -d'=' -f2 | tail -n 1)"
+  else
+    value=NULL
+  fi
+}
+
 function getVersionInfo {
   local version="$1"
   local token="$2"
@@ -19,9 +39,10 @@ function getVersionInfo {
     channel=8
   fi
   
-  ## TODO : Read values from the new file ##
-  local plexBuild="$(cat /plex-build.txt)"
-  local plexDistro="$(cat /plex-distro.txt)"
+  # Read container architecture info from file created when building Docker image
+  readVarFromConf "plex_build" plexBuild
+  readVarFromConf "plex_distro" plexDistro
+
   local url="https://plex.tv/downloads/details/5?build=${plexBuild}&channel=${channel}&distro=${plexDistro}"
   if [ ${tokenNeeded} -gt 0 ]; then
     url="${url}&X-Plex-Token=${token}"


### PR DESCRIPTION
(EDIT 1: Making my PR explanations more understandable)

Hi Plex Community,

I have a suggestion for the official Plex Docker Image, which is to make it available for different platforms other than Ubuntu/amd64.

**Modification suggested by my branch:**

- ADD: Add environment variables (ARGs in Dockerfile) to be able to create Docker Images for almost any OS and architecture supported by Plex Media Server by only changing these environment variables ;
- ADD: Add a Dockerfile for ubuntu/arm64 platforms ;
- EDIT: Update S6-Overlay to a more recent version, which now supports new architectures like ARM ;
- EDIT: Update package URLs to the latest Plex Download API
> PLEX_BUILD and PLEX_DISTRO environment variables correspond to the "build" and "distro" variables listed in the API 5 JSON, provided by Plex, referencing all available packages : 
> [https://plex.tv/pms/downloads/5.json](https://plex.tv/pms/downloads/5.json)

**Testing environment:**

I have tested this with a **Raspberry Pi 4** with this configuration:

Element | Version
-------- | --------
Motherboard | **Raspberry Pi 4 Model B (4GB RAM)**
Host OS | **Ubuntu Server 19.10 (eoan) [arch=arm64]**
Docker | **Docker CE for Ubuntu 19.04 (disco) [arch=arm64]**
Docker container: Plex Build | **Ubuntu 16.04+ / linux-aarch64 / debian**
Docker container: Plex pkg | **plexmediaserver_1.18.5.2309-f5213a238_arm64.deb**
  
Everything works fine, even updates.  
Please consider merging my branch to this repo, I am available for any feedback!

Greetings