### PR TITLE
Added helper script to allow periodic updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,3 +206,15 @@ Docker on Windows works differently than it does on Linux; it uses a VM to run a
 If the claim token is not added during initial configuration you will need to use ssh tunneling to gain access and setup the server for first run. During first run you setup the server to make it available and configurable. However, this setup option will only be triggered if you access it over http://localhost:32400/web, it will not be triggered if you access it over http://ip_of_server:32400/web. If you are setting up PMS on a headless server, you can use a SSH tunnel to link http://localhost:32400/web (on your current computer) to http://localhost:32400/web (on the headless server running PMS):
 
 `ssh username@ip_of_server -L 32400:ip_of_server:32400 -N`
+
+## Automatic updates
+
+For periodic updates through a scheduler like contab you can use the helper script available inside the images.
+
+The following example would work on the host system with crontab:
+
+```
+0 2 * * * cd path/to/your/plex && docker-compose exec plex /updatecheck.sh
+```
+
+The script would run daily at 02:00 and force a reboot of the plex container if the local version does no longer match the available remote plex version (based on the configured claim token).

--- a/root/updatecheck.sh
+++ b/root/updatecheck.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/with-contenv bash
+
+if !(cat /proc/1/cgroup | grep -q '/docker/'); then
+  echo "Not a docker container"
+  exit 0
+fi
+
+# If we are debugging, enable trace
+if [ "${DEBUG,,}" = "true" ]; then
+  set -x
+fi
+
+. /plex-common.sh
+
+pmsApplicationSupportDir="${PLEX_MEDIA_SERVER_APPLICATION_SUPPORT_DIR:-${HOME}/Library/Application Support}"
+prefFile="${pmsApplicationSupportDir}/Plex Media Server/Preferences.xml"
+
+function getPref {
+  local key="$1"
+
+  xmlstarlet sel -T -t -m "/Preferences" -v "@${key}" -n "${prefFile}"
+}
+
+token="$(getPref "PlexOnlineToken")"
+
+# Determine current version
+if (dpkg --get-selections plexmediaserver 2> /dev/null | grep -wq "install"); then
+  installedVersion=$(dpkg-query -W -f='${Version}' plexmediaserver 2> /dev/null)
+else
+  installedVersion="none"
+fi
+
+# Read set version
+versionToInstall="$(cat /version.txt)"
+if [ -z "${versionToInstall}" ]; then
+  echo "No version specified in install.  Broken image"
+  exit 1
+fi
+
+# Short-circuit test of version before remote check to see if it's already installed.
+if [ "${versionToInstall}" = "${installedVersion}" ]; then
+  exit 0
+fi
+
+# Get updated version number
+getVersionInfo "${versionToInstall}" "${token}" remoteVersion remoteFile
+
+if [ -z "${remoteVersion}" ] || [ -z "${remoteFile}" ]; then
+  echo "Could not get update version"
+  exit 0
+fi
+
+# Check if there's no update required and silently exit
+if [ "${remoteVersion}" = "${installedVersion}" ]; then
+  exit 0
+fi
+
+echo "Local version: ${installedVersion}"
+echo "Remove version: ${remoteVersion}"
+echo "Triggering reboot to force update"
+kill 1


### PR DESCRIPTION
I'm unsure about the contribution guidelines here, so I'll just create a PR for this.

This little helper script uses the available configuration, plex claim token and available tools to check for a new version of plex. If found, it kills the primary process for that docker container. That allows for docker host systems with a restart directive to reboot and download the newest binary without any additions/modifications to that mechanic.

This allows to be configured through host systems crontab, see last section in the README.md.