### PR TITLE
Only chown files that have incorrect user/group

### DIFF
--- a/root/etc/cont-init.d/40-plex-first-run
+++ b/root/etc/cont-init.d/40-plex-first-run
@@ -67,10 +67,10 @@ fi
 if [ "${CHANGE_CONFIG_DIR_OWNERSHIP,,}" = "true" ]; then
   if [ -f "${prefFile}" ]; then
     if [ ! "$(stat -c %u "${prefFile}")" = "$(id -u plex)" ]; then
-      chown -R plex:plex /config
+      find /config \! \( -uid $(id -u plex) -gid $(id -g plex) \) -exec chown plex:plex {} \;
     fi
   else
-    chown -R plex:plex /config
+    find /config \! \( -uid $(id -u plex) -gid $(id -g plex) \) -exec chown plex:plex {} \;
   fi
   chown -R plex:plex /transcode
 fi


### PR DESCRIPTION
Not all files will need to change user/group and doing for every file can take a
very long time for large libraries. This commit will use find to find files/dir
that have incorrect user/group and change them.

Hopefully, this should be quicker than going through and changing every single
file.

To be honest, I am still not sure about this approach as it still can take a while to complete.

The main issue for me is that I am using this image in Kubernetes and because there are liveness/readiness checks, it keeps getting recreated (readiness check is timing out). Ideally, I would like to see this maybe as a separate 'init' step, but I'll look at that and see if can create a new PR for it.