### PR TITLE
add localhost mapping to `/etc/hosts`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,8 @@ RUN \
       beignet-opencl-icd \
       ocl-icd-libopencl1 \
     && \
+    echo "127.0.0.1 localhost" >> /etc/hosts
+    && \
     \
 # Fetch and extract S6 overlay
     curl -J -L -o /tmp/s6-overlay-${S6_OVERLAY_ARCH}.tar.gz https://github.com/just-containers/s6-overlay/releases/download/${S6_OVERLAY_VERSION}/s6-overlay-${S6_OVERLAY_ARCH}.tar.gz && \


### PR DESCRIPTION
The health check for my container continually failed with the following message:
``` bash
curl: (6) Could not resolve host: localhost
```
I checked my `/etc/hosts` file and there was no `localhost` mapping. After running 
``` bash
echo "127.0.0.1 localhost" >> /etc/hosts
```
the health check was successful. 

I'm not sure if it's better to change `healthcheck.sh` or the `Dockerfile`, but I choose the `Dockerfile` since there may be other processes using `localhost`.