### PR TITLE
Fix bridge docker compose template

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ plexinc/pms-docker
 Note: In this configuration, you must do some additional configuration:
 
 - If you wish your Plex Media Server to be accessible outside of your home network, you must manually setup port forwarding on your router to forward to the `ADVERTISE_IP` specified above.  By default you can forward port 32400, but if you choose to use a different external port, be sure you configure this in Plex Media Server's `Remote Access` settings.  With this type of docker networking, the Plex Media Server is essentially behind two routers and it cannot automatically setup port forwarding on its own.
-- (Plex Pass only) After the server has been set up, you should configure the `LAN Networks` preference to contain the network of your LAN.  This instructs the Plex Media Server to treat these IP addresses as part of your LAN when applying bandwidth controls.  The syntax is the same as the `ALLOWED_NETWORKS` below.  For example `192.168.1.0/24,172.16.0.0/16` will allow access to the entire `192.168.1.x` range and the `172.16.x.x` range.
+- After the server has been set up, you should configure the `LAN Networks` preference to contain the network of your LAN.  This instructs the Plex Media Server to treat these IP addresses as part of your LAN when applying bandwidth controls.  The syntax is the same as the `ALLOWED_NETWORKS` below.  For example `192.168.1.0/24,172.16.0.0/16` will allow access to the entire `192.168.1.x` range and the `172.16.x.x` range.
 
 ### Using `docker-compose` on ARM devices
 

--- a/docker-compose-bridge.yml.template
+++ b/docker-compose-bridge.yml.template
@@ -18,6 +18,7 @@ services:
       - TZ=<timezone>
       - PLEX_CLAIM=<claimToken>
       - ADVERTISE_IP=http://<hostIPAddress>:32400/
+      - ALLOWED_NETWORKS=<hostIPAddressCIDRRange>
     hostname: <hostname>
     volumes:
       - <path/to/plex/database>:/config


### PR DESCRIPTION
Hey guys, two little fixes regarding the `ALLOWED_NETWORKS` env variable usage

- template is incorrect because plex won't let you use customConnections
(via ADVERTISE_IP) if the given ip is not in the range of the
ALLOWED_NETWORKS
- "(plex pass only)" was incorrect, the ALLOWED_NETWORKS must be set
regardless, if you want to run the container in bridge mode