### PR TITLE
Add --force-architecture to dpkg installation command

### DIFF
--- a/root/plex-common.sh
+++ b/root/plex-common.sh
@@ -71,6 +71,6 @@ function installFromRawUrl {
     exit 1
   fi
 
-  dpkg -i --force-confold /tmp/plexmediaserver.deb
+  dpkg -i --force-confold --force-architecture  /tmp/plexmediaserver.deb
   rm -f /tmp/plexmediaserver.deb
 }


### PR DESCRIPTION
Mitigates an ARM installation issue:

```dpkg: error processing archive /tmp/plexmediaserver.deb (--install):
 package architecture (arm64) does not match system (armhf)
```