### PR TITLE
Add --max-time 100 to healthcheck

### DIFF
--- a/root/healthcheck.sh
+++ b/root/healthcheck.sh
@@ -1,7 +1,7 @@
 #!/bin/sh -e
 
 TARGET=localhost
-CURL_OPTS="--connect-timeout 15 --max-time 30 --silent --show-error --fail"
+CURL_OPTS="--connect-timeout 15 --max-time 100 --silent --show-error --fail"
 
 curl ${CURL_OPTS} "http://${TARGET}:32400/identity" >/dev/null
 

--- a/root/healthcheck.sh
+++ b/root/healthcheck.sh
@@ -1,7 +1,7 @@
 #!/bin/sh -e
 
 TARGET=localhost
-CURL_OPTS="--connect-timeout 15 --silent --show-error --fail"
+CURL_OPTS="--connect-timeout 15 --max-time 30 --silent --show-error --fail"
 
 curl ${CURL_OPTS} "http://${TARGET}:32400/identity" >/dev/null
 


### PR DESCRIPTION
If Plex is running and accepting TCP connections on 32400 but is unable to send a response, curl will wait indefinitley until it does.

Adding `--max-time 60` sets an upper limit for how long curl will wait for a response.  If this is reached, curl will exit with an error status which lines up with the existing use of `--fail` to catch HTTP error responses.