### PR TITLE
Change chown to modify ownership symlinks

### DIFF
--- a/root/etc/cont-init.d/40-plex-first-run
+++ b/root/etc/cont-init.d/40-plex-first-run
@@ -67,10 +67,10 @@ fi
 if [ "${CHANGE_CONFIG_DIR_OWNERSHIP,,}" = "true" ]; then
   if [ -f "${prefFile}" ]; then
     if [ ! "$(stat -c %u "${prefFile}")" = "$(id -u plex)" ]; then
-      find /config \! \( -uid $(id -u plex) -gid $(id -g plex) \) -print0 | xargs -0 chown plex:plex
+      find /config \! \( -uid $(id -u plex) -gid $(id -g plex) \) -print0 | xargs -0 chown -h plex:plex
     fi
   else
-    find /config \! \( -uid $(id -u plex) -gid $(id -g plex) \) -print0 | xargs -0 chown plex:plex
+    find /config \! \( -uid $(id -u plex) -gid $(id -g plex) \) -print0 | xargs -0 chown -h plex:plex
   fi
   chown -R plex:plex /transcode
 fi


### PR DESCRIPTION
It is possible to end up with a long startup period if symlinks have incorrect ownership as they've never corrected by this script currently so each new docker pull they are found by find and the target ownership is updated (despite being correct) causing a delay in startup

This change assumes that all symlink targets are also within the /config directory tree otherwise the targets could be left unchanged as chown no longer follows the links. Alternatively we could run the command twice once for targets & once for symlinks themselves.