### PR TITLE
Update README.md - add note about WSL2

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,8 @@ Your mileage may vary when enabling hardware transcoding as newer generations of
 
 Docker on Windows works differently than it does on Linux; it uses a VM to run a stripped-down Linux and then runs docker within that.  The volume mounts are exposed to the docker in this VM via SMB mounts.  While this is fine for media, it is unacceptable for the `/config` directory because SMB does not support file locking.  This **will** eventually corrupt your database which can lead to slow behavior and crashes.  If you must run in docker on Windows, you should put the `/config` directory mount inside the VM and not on the Windows host.  It's worth noting that this warning also extends to other containers which use SQLite databases.
 
+**NOTE:** The above warning does *not* apply to Docker running on WSL 2.  It is safe to mount `/config` on a Windows host so long as Docker is running on the WSL2 backend.
+
 ## Running on a headless server with container using host networking
 
 If the claim token is not added during initial configuration you will need to use ssh tunneling to gain access and setup the server for first run. During first run you setup the server to make it available and configurable. However, this setup option will only be triggered if you access it over http://localhost:32400/web, it will not be triggered if you access it over http://ip_of_server:32400/web. If you are setting up PMS on a headless server, you can use a SSH tunnel to link http://localhost:32400/web (on your current computer) to http://localhost:32400/web (on the headless server running PMS):


### PR DESCRIPTION
Is it safe to keep the `/config` directory on a Windows host if Docker is running on WSL2?

I've been posting to various Plex forums around the internet trying to get an answer to this question.  Nobody seems to know, so I'm asking here.  

Anecdotally, I have been running with `/config` on the WSL2 Windows host with for over a month with no corruption issues.  On Hyper-V, the database would become corrupt within a matter of hours or days.