### PR TITLE
add connectivity check to plex.tv on startup with wait and backoff

### DIFF
--- a/root/etc/cont-init.d/30-check-connectivity
+++ b/root/etc/cont-init.d/30-check-connectivity
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# verify conenctivity and sleep until established with backoff
+SLEEP_SECS=10
+echo "Verifying connectivity to https://plex.tv."
+until curl https://plex.tv -s -o /dev/null; do
+  echo "Can not connect to https://plex.tv, sleeping $SLEEP_SECS seconds."
+  sleep $SLEEP_SECS
+  SLEEP_SECS=$(($SLEEP_SECS*2))
+done


### PR DESCRIPTION
At times on a cold boot there is race condition with my plex container starting and the network/dns being fully up.  When this happens the plex container gets stuck and never recovers once the network is fully up.

This PR adds a very simple check that the container can reach https://plex.tv before continuing its startup.  If it can't be reached it'll sleep 10 seconds and try again doubling the length of the sleep each time.