### PR TITLE
Remove unused port 3005 from docker-compose template and readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,6 @@ docker run \
 -d \
 --name plex \
 -p 32400:32400/tcp \
--p 3005:3005/tcp \
 -p 8324:8324/tcp \
 -p 32469:32469/tcp \
 -p 1900:1900/udp \

--- a/docker-compose-bridge.yml.template
+++ b/docker-compose-bridge.yml.template
@@ -6,7 +6,6 @@ services:
     restart: unless-stopped
     ports:
       - 32400:32400/tcp
-      - 3005:3005/tcp
       - 8324:8324/tcp
       - 32469:32469/tcp
       - 1900:1900/udp


### PR DESCRIPTION
We want docker-compose and documentation aligned with Dockerfile commit https://github.com/plexinc/pms-docker/commit/61178f762e30348de2753cdad40df6e5b3ac6555