### PR TITLE
Get the direct url from versionInfo

### DIFF
--- a/root/plex-common.sh
+++ b/root/plex-common.sh
@@ -52,12 +52,12 @@ function getVersionInfo {
 
   # Get update info from the XML.  Note: This could countain multiple updates when user specifies an exact version with the lowest first, so we'll use first always.
   getVersionInfo_remoteVersion=$(echo "${versionInfo}" | sed -n 's/.*Release.*version="\([^"]*\)".*/\1/p')
-  getVersionInfo_remoteFile=$(echo "${versionInfo}" | sed -n 's/.*file="\([^"]*\)".*/\1/p')
+  getVersionInfo_remoteFile=$(echo "${versionInfo}" | sed -n 's/.*url="\([^"]*\)".*/\1/p')
 }
 
 
 function installFromUrl {
-  installFromRawUrl "https://plex.tv/${1}"
+  installFromRawUrl "${1}"
 }
 
 function installFromRawUrl {


### PR DESCRIPTION
Some users seem to occasionally experience the binary not being downloaded, maybe the following redirect isn't always in place?
```
https://plex.tv/updater/packages/<some id>/file
```
Any reason not to just fetch the url directly like my suggested fix?

Example xml
```xml
<?xml version="1.0" encoding="UTF-8"?>
<MediaContainer friendlyName="myPlex" identifier="com.plexapp.plugins.myplex" machineIdentifier="c5dc113aaebf26e80e30c6b20dbdead4e4bcce1a" size="1" title="Download details">
  <Release id="4766" version="1.30.2.6563-3d4dc0cce" added="(NAS) Add Support for TerraMaster TOS 5 platforms.&#10;(Scanner) .plexmatch files now support a new match type called &quot;SEE&quot;, which allows handling of files where e.g. &quot;302&quot; means episode 2 of season 3 (#13985)&#10;(Scanner) .plexmatch pattern matching tokens now support setting a maximum length on matches; see the &quot;Match Hinting for TV Series&quot; support article for details (#13985)&#10;(Scanner) Files named using the uncommon &quot;SEE&quot; format are no longer matched by default; please use the .plexmatch feature to handle these files (#13985)&#10;(Scanner) Files with names containing a 3- or 4-digit standalone episode number are now matched correctly by default (#13985)" fixed="(DLNA) Corrected DLNA server not starting on NVIDIA Shield (#13340)&#10;(DVR) DVR schedule is now corrected when the guide updates. (#13217/#12821)&#10;(DVR) Preview thumbs not being created for DVR recordings (#13943)&#10;(Library) TV theme music could incorrectly remain on an item after fixing a match (#13933)&#10;(Library) Unprocessed Add to Library items can crash the server on startup if the original library section no longer exists (#14022)&#10;(MacOS) Incorrect download progress percentage for updates is passed to the web client (#13992)&#10;(Metadata) Episodes would not store the year field (#13974)&#10;(Music) Improve reliability of maintaining original add date when upgrading albums.&#10;(Music) When replacing exisiting files with new versions, loudness analysis would not trigger on demand (#13897)&#10;(Network) The server could fail to publish any LAN addresses if a preferred network interface was selected, but was not available (#14001)&#10;(Pivots) Categories pivot loading time might be slow for larger libraries (#13912)&#10;(Transcoder) Decoding certain TrueHD audio streams could fail (#14023)&#10;(Transcoder) Download transcodes consumed slot even after transcode completes (#13987)&#10;(Versions) Optimized versions of an edition would overwrite any existing version using the same profile (#13746)&#10;(macOS) Some endpoints could return errors on macOS versions older than 10.15 (#13946)" live="1" autoupdate="1" createdAt="2023-01-10 20:46:09 UTC">
    <Package manifest="/updater/packages/154868/manifest" manifestHash="" manifestHashSha256="" file="/updater/packages/154868/file" fileHash="7707f197170ed0f7d7b9df8e8096177a9373d682" fileHashSha256="f15524791c699815c33f83215b22a9e861272b6f4bf8e875dacfdba48777bd7a" fileName="plexmediaserver_1.30.2.6563-3d4dc0cce_amd64.deb" delta="0" url="https://downloads.plex.tv/plex-media-server-new/1.30.2.6563-3d4dc0cce/debian/plexmediaserver_1.30.2.6563-3d4dc0cce_amd64.deb"/>
  </Release>
</MediaContainer>
```