### PR TITLE
feat: Move /.firstRunComplete to /tmp to prepare readonly rootfs

### DIFF
--- a/root/etc/cont-init.d/40-plex-first-run
+++ b/root/etc/cont-init.d/40-plex-first-run
@@ -6,7 +6,7 @@ if [ "${DEBUG,,}" = "true" ]; then
 fi
 
 # If the first run completed successfully, we are done
-if [ -e /.firstRunComplete ]; then
+if [ -e /tmp/.firstRunComplete ]; then
   exit 0
 fi
 
@@ -136,5 +136,5 @@ if [ -z "$(getPref "TranscoderTempDirectory")" ]; then
   setPref "TranscoderTempDirectory" "/transcode"
 fi
 
-touch /.firstRunComplete
+touch /tmp/.firstRunComplete
 echo "Plex Media Server first run setup complete"


### PR DESCRIPTION
I currently migrate all my Kubernetes workloads to containers with read-only rootfs.

The plex container is a bit tricky with the `/.firstRunComplete` file. If you'd move that file to `/tmp`, it would be possible to mount a temporary filesystem which is writable (Kubernetes `emptyDir`) below /tmp.

The s6 suite also have issues with read-only rootfs but it (officially) supports it by setting `S6_READ_ONLY_ROOT=1`. Ref: https://github.com/just-containers/s6-overlay#read-only-root-filesystem