### PR TITLE
feat: add a helm chart to deploy PMS Kubernetes 

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,86 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, caste, color, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our community include:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
+- Focusing on what is best not just for us as individuals, but for the overall community
+
+Examples of unacceptable behavior include:
+
+- The use of sexualized language or imagery, and sexual attention or advances of any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or email address, without their explicit permission
+- Publishing spam or promotional links
+- Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces.
+
+Examples of representing our community include using an official e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at opensource@plex.tv. All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, for a specified period of time. This includes avoiding interactions in community spaces as well as external channels like social media. Violating these terms may lead to a temporary or permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public communication with the community for a specified period of time. No public or private interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, is allowed during this period. Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community standards, including sustained inappropriate behavior, harassment of an individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct enforcement ladder][mozilla coc].
+
+For answers to common questions about this code of conduct, see the FAQ at [https://www.contributor-covenant.org/faq][faq]. Translations are available at [https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[mozilla coc]: https://github.com/mozilla/diversity
+[faq]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/charts/plex-media-server/.helmignore
+++ b/charts/plex-media-server/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/plex-media-server/Chart.yaml
+++ b/charts/plex-media-server/Chart.yaml
@@ -1,0 +1,34 @@
+apiVersion: v2
+name: plex-media-server
+description: A Helm chart for deploying a PMS server to a kubernetes cluster
+
+keywords:
+- plex
+- pms
+- Personal Media Server
+
+home: https://www.plex.tv
+icon: https://www.plex.tv/wp-content/themes/plex/assets/img/favicons/plex-152.png
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "1.16.0"
+
+sources:
+- https://github.com/plexinc/pms-docker

--- a/charts/plex-media-server/LICENSE
+++ b/charts/plex-media-server/LICENSE
@@ -1,0 +1,674 @@
+                    GNU GENERAL PUBLIC LICENSE
+                       Version 3, 29 June 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The GNU General Public License is a free, copyleft license for
+software and other kinds of works.
+
+  The licenses for most software and other practical works are designed
+to take away your freedom to share and change the works.  By contrast,
+the GNU General Public License is intended to guarantee your freedom to
+share and change all versions of a program--to make sure it remains free
+software for all its users.  We, the Free Software Foundation, use the
+GNU General Public License for most of our software; it applies also to
+any other work released this way by its authors.  You can apply it to
+your programs, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+them if you wish), that you receive source code or can get it if you
+want it, that you can change the software or use pieces of it in new
+free programs, and that you know you can do these things.
+
+  To protect your rights, we need to prevent others from denying you
+these rights or asking you to surrender the rights.  Therefore, you have
+certain responsibilities if you distribute copies of the software, or if
+you modify it: responsibilities to respect the freedom of others.
+
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must pass on to the recipients the same
+freedoms that you received.  You must make sure that they, too, receive
+or can get the source code.  And you must show them these terms so they
+know their rights.
+
+  Developers that use the GNU GPL protect your rights with two steps:
+(1) assert copyright on the software, and (2) offer you this License
+giving you legal permission to copy, distribute and/or modify it.
+
+  For the developers' and authors' protection, the GPL clearly explains
+that there is no warranty for this free software.  For both users' and
+authors' sake, the GPL requires that modified versions be marked as
+changed, so that their problems will not be attributed erroneously to
+authors of previous versions.
+
+  Some devices are designed to deny users access to install or run
+modified versions of the software inside them, although the manufacturer
+can do so.  This is fundamentally incompatible with the aim of
+protecting users' freedom to change the software.  The systematic
+pattern of such abuse occurs in the area of products for individuals to
+use, which is precisely where it is most unacceptable.  Therefore, we
+have designed this version of the GPL to prohibit the practice for those
+products.  If such problems arise substantially in other domains, we
+stand ready to extend this provision to those domains in future versions
+of the GPL, as needed to protect the freedom of users.
+
+  Finally, every program is threatened constantly by software patents.
+States should not allow patents to restrict development and use of
+software on general-purpose computers, but in those that do, we wish to
+avoid the special danger that patents applied to a free program could
+make it effectively proprietary.  To prevent this, the GPL assures that
+patents cannot be used to render the program non-free.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                       TERMS AND CONDITIONS
+
+  0. Definitions.
+
+  "This License" refers to version 3 of the GNU General Public License.
+
+  "Copyright" also means copyright-like laws that apply to other kinds of
+works, such as semiconductor masks.
+
+  "The Program" refers to any copyrightable work licensed under this
+License.  Each licensee is addressed as "you".  "Licensees" and
+"recipients" may be individuals or organizations.
+
+  To "modify" a work means to copy from or adapt all or part of the work
+in a fashion requiring copyright permission, other than the making of an
+exact copy.  The resulting work is called a "modified version" of the
+earlier work or a work "based on" the earlier work.
+
+  A "covered work" means either the unmodified Program or a work based
+on the Program.
+
+  To "propagate" a work means to do anything with it that, without
+permission, would make you directly or secondarily liable for
+infringement under applicable copyright law, except executing it on a
+computer or modifying a private copy.  Propagation includes copying,
+distribution (with or without modification), making available to the
+public, and in some countries other activities as well.
+
+  To "convey" a work means any kind of propagation that enables other
+parties to make or receive copies.  Mere interaction with a user through
+a computer network, with no transfer of a copy, is not conveying.
+
+  An interactive user interface displays "Appropriate Legal Notices"
+to the extent that it includes a convenient and prominently visible
+feature that (1) displays an appropriate copyright notice, and (2)
+tells the user that there is no warranty for the work (except to the
+extent that warranties are provided), that licensees may convey the
+work under this License, and how to view a copy of this License.  If
+the interface presents a list of user commands or options, such as a
+menu, a prominent item in the list meets this criterion.
+
+  1. Source Code.
+
+  The "source code" for a work means the preferred form of the work
+for making modifications to it.  "Object code" means any non-source
+form of a work.
+
+  A "Standard Interface" means an interface that either is an official
+standard defined by a recognized standards body, or, in the case of
+interfaces specified for a particular programming language, one that
+is widely used among developers working in that language.
+
+  The "System Libraries" of an executable work include anything, other
+than the work as a whole, that (a) is included in the normal form of
+packaging a Major Component, but which is not part of that Major
+Component, and (b) serves only to enable use of the work with that
+Major Component, or to implement a Standard Interface for which an
+implementation is available to the public in source code form.  A
+"Major Component", in this context, means a major essential component
+(kernel, window system, and so on) of the specific operating system
+(if any) on which the executable work runs, or a compiler used to
+produce the work, or an object code interpreter used to run it.
+
+  The "Corresponding Source" for a work in object code form means all
+the source code needed to generate, install, and (for an executable
+work) run the object code and to modify the work, including scripts to
+control those activities.  However, it does not include the work's
+System Libraries, or general-purpose tools or generally available free
+programs which are used unmodified in performing those activities but
+which are not part of the work.  For example, Corresponding Source
+includes interface definition files associated with source files for
+the work, and the source code for shared libraries and dynamically
+linked subprograms that the work is specifically designed to require,
+such as by intimate data communication or control flow between those
+subprograms and other parts of the work.
+
+  The Corresponding Source need not include anything that users
+can regenerate automatically from other parts of the Corresponding
+Source.
+
+  The Corresponding Source for a work in source code form is that
+same work.
+
+  2. Basic Permissions.
+
+  All rights granted under this License are granted for the term of
+copyright on the Program, and are irrevocable provided the stated
+conditions are met.  This License explicitly affirms your unlimited
+permission to run the unmodified Program.  The output from running a
+covered work is covered by this License only if the output, given its
+content, constitutes a covered work.  This License acknowledges your
+rights of fair use or other equivalent, as provided by copyright law.
+
+  You may make, run and propagate covered works that you do not
+convey, without conditions so long as your license otherwise remains
+in force.  You may convey covered works to others for the sole purpose
+of having them make modifications exclusively for you, or provide you
+with facilities for running those works, provided that you comply with
+the terms of this License in conveying all material for which you do
+not control copyright.  Those thus making or running the covered works
+for you must do so exclusively on your behalf, under your direction
+and control, on terms that prohibit them from making any copies of
+your copyrighted material outside their relationship with you.
+
+  Conveying under any other circumstances is permitted solely under
+the conditions stated below.  Sublicensing is not allowed; section 10
+makes it unnecessary.
+
+  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+
+  No covered work shall be deemed part of an effective technological
+measure under any applicable law fulfilling obligations under article
+11 of the WIPO copyright treaty adopted on 20 December 1996, or
+similar laws prohibiting or restricting circumvention of such
+measures.
+
+  When you convey a covered work, you waive any legal power to forbid
+circumvention of technological measures to the extent such circumvention
+is effected by exercising rights under this License with respect to
+the covered work, and you disclaim any intention to limit operation or
+modification of the work as a means of enforcing, against the work's
+users, your or third parties' legal rights to forbid circumvention of
+technological measures.
+
+  4. Conveying Verbatim Copies.
+
+  You may convey verbatim copies of the Program's source code as you
+receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice;
+keep intact all notices stating that this License and any
+non-permissive terms added in accord with section 7 apply to the code;
+keep intact all notices of the absence of any warranty; and give all
+recipients a copy of this License along with the Program.
+
+  You may charge any price or no price for each copy that you convey,
+and you may offer support or warranty protection for a fee.
+
+  5. Conveying Modified Source Versions.
+
+  You may convey a work based on the Program, or the modifications to
+produce it from the Program, in the form of source code under the
+terms of section 4, provided that you also meet all of these conditions:
+
+    a) The work must carry prominent notices stating that you modified
+    it, and giving a relevant date.
+
+    b) The work must carry prominent notices stating that it is
+    released under this License and any conditions added under section
+    7.  This requirement modifies the requirement in section 4 to
+    "keep intact all notices".
+
+    c) You must license the entire work, as a whole, under this
+    License to anyone who comes into possession of a copy.  This
+    License will therefore apply, along with any applicable section 7
+    additional terms, to the whole of the work, and all its parts,
+    regardless of how they are packaged.  This License gives no
+    permission to license the work in any other way, but it does not
+    invalidate such permission if you have separately received it.
+
+    d) If the work has interactive user interfaces, each must display
+    Appropriate Legal Notices; however, if the Program has interactive
+    interfaces that do not display Appropriate Legal Notices, your
+    work need not make them do so.
+
+  A compilation of a covered work with other separate and independent
+works, which are not by their nature extensions of the covered work,
+and which are not combined with it such as to form a larger program,
+in or on a volume of a storage or distribution medium, is called an
+"aggregate" if the compilation and its resulting copyright are not
+used to limit the access or legal rights of the compilation's users
+beyond what the individual works permit.  Inclusion of a covered work
+in an aggregate does not cause this License to apply to the other
+parts of the aggregate.
+
+  6. Conveying Non-Source Forms.
+
+  You may convey a covered work in object code form under the terms
+of sections 4 and 5, provided that you also convey the
+machine-readable Corresponding Source under the terms of this License,
+in one of these ways:
+
+    a) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by the
+    Corresponding Source fixed on a durable physical medium
+    customarily used for software interchange.
+
+    b) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by a
+    written offer, valid for at least three years and valid for as
+    long as you offer spare parts or customer support for that product
+    model, to give anyone who possesses the object code either (1) a
+    copy of the Corresponding Source for all the software in the
+    product that is covered by this License, on a durable physical
+    medium customarily used for software interchange, for a price no
+    more than your reasonable cost of physically performing this
+    conveying of source, or (2) access to copy the
+    Corresponding Source from a network server at no charge.
+
+    c) Convey individual copies of the object code with a copy of the
+    written offer to provide the Corresponding Source.  This
+    alternative is allowed only occasionally and noncommercially, and
+    only if you received the object code with such an offer, in accord
+    with subsection 6b.
+
+    d) Convey the object code by offering access from a designated
+    place (gratis or for a charge), and offer equivalent access to the
+    Corresponding Source in the same way through the same place at no
+    further charge.  You need not require recipients to copy the
+    Corresponding Source along with the object code.  If the place to
+    copy the object code is a network server, the Corresponding Source
+    may be on a different server (operated by you or a third party)
+    that supports equivalent copying facilities, provided you maintain
+    clear directions next to the object code saying where to find the
+    Corresponding Source.  Regardless of what server hosts the
+    Corresponding Source, you remain obligated to ensure that it is
+    available for as long as needed to satisfy these requirements.
+
+    e) Convey the object code using peer-to-peer transmission, provided
+    you inform other peers where the object code and Corresponding
+    Source of the work are being offered to the general public at no
+    charge under subsection 6d.
+
+  A separable portion of the object code, whose source code is excluded
+from the Corresponding Source as a System Library, need not be
+included in conveying the object code work.
+
+  A "User Product" is either (1) a "consumer product", which means any
+tangible personal property which is normally used for personal, family,
+or household purposes, or (2) anything designed or sold for incorporation
+into a dwelling.  In determining whether a product is a consumer product,
+doubtful cases shall be resolved in favor of coverage.  For a particular
+product received by a particular user, "normally used" refers to a
+typical or common use of that class of product, regardless of the status
+of the particular user or of the way in which the particular user
+actually uses, or expects or is expected to use, the product.  A product
+is a consumer product regardless of whether the product has substantial
+commercial, industrial or non-consumer uses, unless such uses represent
+the only significant mode of use of the product.
+
+  "Installation Information" for a User Product means any methods,
+procedures, authorization keys, or other information required to install
+and execute modified versions of a covered work in that User Product from
+a modified version of its Corresponding Source.  The information must
+suffice to ensure that the continued functioning of the modified object
+code is in no case prevented or interfered with solely because
+modification has been made.
+
+  If you convey an object code work under this section in, or with, or
+specifically for use in, a User Product, and the conveying occurs as
+part of a transaction in which the right of possession and use of the
+User Product is transferred to the recipient in perpetuity or for a
+fixed term (regardless of how the transaction is characterized), the
+Corresponding Source conveyed under this section must be accompanied
+by the Installation Information.  But this requirement does not apply
+if neither you nor any third party retains the ability to install
+modified object code on the User Product (for example, the work has
+been installed in ROM).
+
+  The requirement to provide Installation Information does not include a
+requirement to continue to provide support service, warranty, or updates
+for a work that has been modified or installed by the recipient, or for
+the User Product in which it has been modified or installed.  Access to a
+network may be denied when the modification itself materially and
+adversely affects the operation of the network or violates the rules and
+protocols for communication across the network.
+
+  Corresponding Source conveyed, and Installation Information provided,
+in accord with this section must be in a format that is publicly
+documented (and with an implementation available to the public in
+source code form), and must require no special password or key for
+unpacking, reading or copying.
+
+  7. Additional Terms.
+
+  "Additional permissions" are terms that supplement the terms of this
+License by making exceptions from one or more of its conditions.
+Additional permissions that are applicable to the entire Program shall
+be treated as though they were included in this License, to the extent
+that they are valid under applicable law.  If additional permissions
+apply only to part of the Program, that part may be used separately
+under those permissions, but the entire Program remains governed by
+this License without regard to the additional permissions.
+
+  When you convey a copy of a covered work, you may at your option
+remove any additional permissions from that copy, or from any part of
+it.  (Additional permissions may be written to require their own
+removal in certain cases when you modify the work.)  You may place
+additional permissions on material, added by you to a covered work,
+for which you have or can give appropriate copyright permission.
+
+  Notwithstanding any other provision of this License, for material you
+add to a covered work, you may (if authorized by the copyright holders of
+that material) supplement the terms of this License with terms:
+
+    a) Disclaiming warranty or limiting liability differently from the
+    terms of sections 15 and 16 of this License; or
+
+    b) Requiring preservation of specified reasonable legal notices or
+    author attributions in that material or in the Appropriate Legal
+    Notices displayed by works containing it; or
+
+    c) Prohibiting misrepresentation of the origin of that material, or
+    requiring that modified versions of such material be marked in
+    reasonable ways as different from the original version; or
+
+    d) Limiting the use for publicity purposes of names of licensors or
+    authors of the material; or
+
+    e) Declining to grant rights under trademark law for use of some
+    trade names, trademarks, or service marks; or
+
+    f) Requiring indemnification of licensors and authors of that
+    material by anyone who conveys the material (or modified versions of
+    it) with contractual assumptions of liability to the recipient, for
+    any liability that these contractual assumptions directly impose on
+    those licensors and authors.
+
+  All other non-permissive additional terms are considered "further
+restrictions" within the meaning of section 10.  If the Program as you
+received it, or any part of it, contains a notice stating that it is
+governed by this License along with a term that is a further
+restriction, you may remove that term.  If a license document contains
+a further restriction but permits relicensing or conveying under this
+License, you may add to a covered work material governed by the terms
+of that license document, provided that the further restriction does
+not survive such relicensing or conveying.
+
+  If you add terms to a covered work in accord with this section, you
+must place, in the relevant source files, a statement of the
+additional terms that apply to those files, or a notice indicating
+where to find the applicable terms.
+
+  Additional terms, permissive or non-permissive, may be stated in the
+form of a separately written license, or stated as exceptions;
+the above requirements apply either way.
+
+  8. Termination.
+
+  You may not propagate or modify a covered work except as expressly
+provided under this License.  Any attempt otherwise to propagate or
+modify it is void, and will automatically terminate your rights under
+this License (including any patent licenses granted under the third
+paragraph of section 11).
+
+  However, if you cease all violation of this License, then your
+license from a particular copyright holder is reinstated (a)
+provisionally, unless and until the copyright holder explicitly and
+finally terminates your license, and (b) permanently, if the copyright
+holder fails to notify you of the violation by some reasonable means
+prior to 60 days after the cessation.
+
+  Moreover, your license from a particular copyright holder is
+reinstated permanently if the copyright holder notifies you of the
+violation by some reasonable means, this is the first time you have
+received notice of violation of this License (for any work) from that
+copyright holder, and you cure the violation prior to 30 days after
+your receipt of the notice.
+
+  Termination of your rights under this section does not terminate the
+licenses of parties who have received copies or rights from you under
+this License.  If your rights have been terminated and not permanently
+reinstated, you do not qualify to receive new licenses for the same
+material under section 10.
+
+  9. Acceptance Not Required for Having Copies.
+
+  You are not required to accept this License in order to receive or
+run a copy of the Program.  Ancillary propagation of a covered work
+occurring solely as a consequence of using peer-to-peer transmission
+to receive a copy likewise does not require acceptance.  However,
+nothing other than this License grants you permission to propagate or
+modify any covered work.  These actions infringe copyright if you do
+not accept this License.  Therefore, by modifying or propagating a
+covered work, you indicate your acceptance of this License to do so.
+
+  10. Automatic Licensing of Downstream Recipients.
+
+  Each time you convey a covered work, the recipient automatically
+receives a license from the original licensors, to run, modify and
+propagate that work, subject to this License.  You are not responsible
+for enforcing compliance by third parties with this License.
+
+  An "entity transaction" is a transaction transferring control of an
+organization, or substantially all assets of one, or subdividing an
+organization, or merging organizations.  If propagation of a covered
+work results from an entity transaction, each party to that
+transaction who receives a copy of the work also receives whatever
+licenses to the work the party's predecessor in interest had or could
+give under the previous paragraph, plus a right to possession of the
+Corresponding Source of the work from the predecessor in interest, if
+the predecessor has it or can get it with reasonable efforts.
+
+  You may not impose any further restrictions on the exercise of the
+rights granted or affirmed under this License.  For example, you may
+not impose a license fee, royalty, or other charge for exercise of
+rights granted under this License, and you may not initiate litigation
+(including a cross-claim or counterclaim in a lawsuit) alleging that
+any patent claim is infringed by making, using, selling, offering for
+sale, or importing the Program or any portion of it.
+
+  11. Patents.
+
+  A "contributor" is a copyright holder who authorizes use under this
+License of the Program or a work on which the Program is based.  The
+work thus licensed is called the contributor's "contributor version".
+
+  A contributor's "essential patent claims" are all patent claims
+owned or controlled by the contributor, whether already acquired or
+hereafter acquired, that would be infringed by some manner, permitted
+by this License, of making, using, or selling its contributor version,
+but do not include claims that would be infringed only as a
+consequence of further modification of the contributor version.  For
+purposes of this definition, "control" includes the right to grant
+patent sublicenses in a manner consistent with the requirements of
+this License.
+
+  Each contributor grants you a non-exclusive, worldwide, royalty-free
+patent license under the contributor's essential patent claims, to
+make, use, sell, offer for sale, import and otherwise run, modify and
+propagate the contents of its contributor version.
+
+  In the following three paragraphs, a "patent license" is any express
+agreement or commitment, however denominated, not to enforce a patent
+(such as an express permission to practice a patent or covenant not to
+sue for patent infringement).  To "grant" such a patent license to a
+party means to make such an agreement or commitment not to enforce a
+patent against the party.
+
+  If you convey a covered work, knowingly relying on a patent license,
+and the Corresponding Source of the work is not available for anyone
+to copy, free of charge and under the terms of this License, through a
+publicly available network server or other readily accessible means,
+then you must either (1) cause the Corresponding Source to be so
+available, or (2) arrange to deprive yourself of the benefit of the
+patent license for this particular work, or (3) arrange, in a manner
+consistent with the requirements of this License, to extend the patent
+license to downstream recipients.  "Knowingly relying" means you have
+actual knowledge that, but for the patent license, your conveying the
+covered work in a country, or your recipient's use of the covered work
+in a country, would infringe one or more identifiable patents in that
+country that you have reason to believe are valid.
+
+  If, pursuant to or in connection with a single transaction or
+arrangement, you convey, or propagate by procuring conveyance of, a
+covered work, and grant a patent license to some of the parties
+receiving the covered work authorizing them to use, propagate, modify
+or convey a specific copy of the covered work, then the patent license
+you grant is automatically extended to all recipients of the covered
+work and works based on it.
+
+  A patent license is "discriminatory" if it does not include within
+the scope of its coverage, prohibits the exercise of, or is
+conditioned on the non-exercise of one or more of the rights that are
+specifically granted under this License.  You may not convey a covered
+work if you are a party to an arrangement with a third party that is
+in the business of distributing software, under which you make payment
+to the third party based on the extent of your activity of conveying
+the work, and under which the third party grants, to any of the
+parties who would receive the covered work from you, a discriminatory
+patent license (a) in connection with copies of the covered work
+conveyed by you (or copies made from those copies), or (b) primarily
+for and in connection with specific products or compilations that
+contain the covered work, unless you entered into that arrangement,
+or that patent license was granted, prior to 28 March 2007.
+
+  Nothing in this License shall be construed as excluding or limiting
+any implied license or other defenses to infringement that may
+otherwise be available to you under applicable patent law.
+
+  12. No Surrender of Others' Freedom.
+
+  If conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot convey a
+covered work so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you may
+not convey it at all.  For example, if you agree to terms that obligate you
+to collect a royalty for further conveying from those to whom you convey
+the Program, the only way you could satisfy both those terms and this
+License would be to refrain entirely from conveying the Program.
+
+  13. Use with the GNU Affero General Public License.
+
+  Notwithstanding any other provision of this License, you have
+permission to link or combine any covered work with a work licensed
+under version 3 of the GNU Affero General Public License into a single
+combined work, and to convey the resulting work.  The terms of this
+License will continue to apply to the part which is the covered work,
+but the special requirements of the GNU Affero General Public License,
+section 13, concerning interaction through a network will apply to the
+combination as such.
+
+  14. Revised Versions of this License.
+
+  The Free Software Foundation may publish revised and/or new versions of
+the GNU General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+  Each version is given a distinguishing version number.  If the
+Program specifies that a certain numbered version of the GNU General
+Public License "or any later version" applies to it, you have the
+option of following the terms and conditions either of that numbered
+version or of any later version published by the Free Software
+Foundation.  If the Program does not specify a version number of the
+GNU General Public License, you may choose any version ever published
+by the Free Software Foundation.
+
+  If the Program specifies that a proxy can decide which future
+versions of the GNU General Public License can be used, that proxy's
+public statement of acceptance of a version permanently authorizes you
+to choose that version for the Program.
+
+  Later license versions may give you additional or different
+permissions.  However, no additional obligations are imposed on any
+author or copyright holder as a result of your choosing to follow a
+later version.
+
+  15. Disclaimer of Warranty.
+
+  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
+OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
+IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. Limitation of Liability.
+
+  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
+THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
+USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
+DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
+PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
+EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGES.
+
+  17. Interpretation of Sections 15 and 16.
+
+  If the disclaimer of warranty and limitation of liability provided
+above cannot be given local legal effect according to their terms,
+reviewing courts shall apply local law that most closely approximates
+an absolute waiver of all civil liability in connection with the
+Program, unless a warranty or assumption of liability accompanies a
+copy of the Program in return for a fee.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+state the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+  If the program does terminal interaction, make it output a short
+notice like this when it starts in an interactive mode:
+
+    <program>  Copyright (C) <year>  <name of author>
+    This program comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License.  Of course, your program's commands
+might be different; for a GUI interface, you would use an "about box".
+
+  You should also get your employer (if you work as a programmer) or school,
+if any, to sign a "copyright disclaimer" for the program, if necessary.
+For more information on this, and how to apply and follow the GNU GPL, see
+<https://www.gnu.org/licenses/>.
+
+  The GNU General Public License does not permit incorporating your program
+into proprietary programs.  If your program is a subroutine library, you
+may consider it more useful to permit linking proprietary applications with
+the library.  If this is what you want to do, use the GNU Lesser General
+Public License instead of this License.  But first, please read
+<https://www.gnu.org/licenses/why-not-lgpl.html>.

--- a/charts/plex-media-server/README.md
+++ b/charts/plex-media-server/README.md
@@ -57,6 +57,14 @@ rm pms.tgz
 echo "Done."
 ```
 
+## Contributing
+
+Before contributing, please read the [Code of Conduct](../../CODE_OF_CONDUCT.md).
+
+## License
+
+[GNU GPLv3](./LICENSE)
+
 ## Configuration
 
 The following table lists the configurable parameters of the Pms-chart chart and their default values.

--- a/charts/plex-media-server/README.md
+++ b/charts/plex-media-server/README.md
@@ -1,0 +1,117 @@
+# plex-media-server Chart
+===========
+
+A Helm chart for deploying the a Plex Personal Media Server(PMS) server.
+
+While Plex is responsible for maintaining this Helm chart, we cannot provide support for troubleshooting related to its usage. For community assistance, please visit our [support forums](https://forums.plex.tv/).
+
+### Sample init Container scripts
+
+If you already have a different PMS server running elsewhere and wish to migrate it to be running in Kubernetes
+the easiest way to do that is to import the existing PMS database through the use of a custom init script.
+
+**Note: the init script must include a mechanism to exit early if the pms database already exists to prevent from overwriting its contents**
+
+The following script is an example (using the default `alpine` init container) that will pull
+a tar gziped file that contains the pms `Library` directory from some web server.
+
+```sh
+#!/bin/sh
+echo "fetching pre-existing pms database to import..."
+
+if [ -d "/config/Library" ]; then
+  echo "PMS library already exists, exiting."
+  exit 0
+fi
+
+apk --no-cache add curl
+curl http://example.com/pms.tgz -o pms.tgz
+tar -xvzf pms.tgz -C /config
+rm pms.tgz
+
+echo "Done."
+```
+
+This next example could be used if you don't have or can't host the existing pms database archive on a web server.
+However, this one _does_ require that two commands are run manually once the init container starts up.
+
+1. Manually copy the pms database into the pod: `kubectl cp pms.tgz <namespace>/<podname>:/pms.tgz.up -c <release name>-pms-chart-pms-init`
+2. Once the file is uploaded copy rename it on the pod to the correct name that will be processed `kubectl exec -n <namespace> --stdin --tty <pod>  -c <release name>-pms-chart-pms-init h  -- mv /pms.tgz.up /pms.tgz`
+
+The file is being uploaded with a temporary name so that the script does not start trying to unpack the database until it has finished uploading.
+```sh
+#!/bin/sh
+echo "waiting for pre-existing pms database to uploaded..."
+
+if [ -d "/config/Library" ]; then
+  echo "PMS library already exists, exiting."
+  exit 0
+fi
+
+# wait for the database archive to be manually copied to the server
+while [ ! -f /pms.tgz ]; do sleep 2; done;
+
+tar -xvzf /pms.tgz -C /config
+rm pms.tgz
+
+echo "Done."
+```
+
+## Configuration
+
+The following table lists the configurable parameters of the Pms-chart chart and their default values.
+
+| Parameter                | Description             | Default        |
+| ------------------------ | ----------------------- | -------------- |
+| `image.registry` | The registry that should be used to pull the image from | `"index.docker.io"` |
+| `image.repository` | The docker repo that will be used for the PMS image | `"plexinc/pms-docker"` |
+| `image.tag` | The tag to use | `"latest"` |
+| `image.sha` | Optional SHA digest to specify a specific image rather than a specific tag | `""` |
+| `image.pullPolicy` |  | `"IfNotPresent"` |
+| `global.imageRegistry` | The image registry that should be used for all images, this will take precedence over the per image registry.  | `""` |
+| `ingress.enabled` | If an ingress for the PMS port should be created. | `false` |
+| `ingress.ingressClassName` |  | `"ingress-nginx"` |
+| `ingress.url` | The url that will be used for the ingress, this should be manually configured as the app URL in PMS. | `""` |
+| `ingress.annotations` | Extra annotations to add to the ingress.  | `{}` |
+| `pms.storageClassName` | The storage class that will be used for the PMS configuration directory, if not specified the default will be used | `null` |
+| `pms.configStorage` | The amount of storage space that is allocated to the config volume, this will probably need to be much higher if thumbnails are enabled.  | `"2Gi"` |
+| `pms.resources` |  | `{}` |
+| `initContainer.image.registry` | The registry that should be used to pull the image from | `"index.docker.io"` |
+| `initContainer.image.repository` | The docker repo that will be used for the init image to run the setup scripts| `"alpine"` |
+| `initContainer.image.tag` | The tag to use | `"3.18.0"` |
+| `initContainer.image.sha` | Optional SHA digest to specify a specific image rather than a specific tag | `""` |
+| `initContainer.image.pullPolicy` |  | `"IfNotPresent"` |
+| `initContainer.script` | An optional script that will be run by the init container, it can be used on the first run to stop pms from starting when importing a pre-exiting database | `""` |
+| `rclone.enabled` | If rclone should be used to mount volumes | `false` |
+| `rclone.image.registry` | The registry that should be used to pull the image from | `"index.docker.io"` |
+| `rclone.image.repository` | The docker repo that will be used for the rclone container | `"rclone/rclone"` |
+| `rclone.image.tag` | The version of rclone to use | `"1.62.2"` |
+| `rclone.image.sha` | Optional SHA digest to specify a specific image rather than a specific tag | `""` |
+| `rclone.image.pullPolicy` |  | `"IfNotPresent"` |
+| `rclone.configSecret` | The name of the Kubernetes secret that contains the rclone config to use. This secret is not created by this chart  | `""` |
+| `rclone.remotes` | A list of remotes to mount using rclone. In the format of `"<remote-name>:<remote-path>"`, the remote-name must be in the rclone config file and its also used to determine the mount path within the PMS container | `[]` |
+| `rclone.readOnly` | If the rclone volumes should be mounted as readonly | `true` |
+| `rclone.additionalArgs` | Optional additional arguments given to the rclone mount command | `[]` |
+| `rclone.resources` |  | `{}` |
+| `imagePullSecrets` |  | `[]` |
+| `nameOverride` |  | `""` |
+| `fullnameOverride` |  | `""` |
+| `serviceAccount.create` |  | `true` |
+| `serviceAccount.automountServiceAccountToken` |  | `false` |
+| `serviceAccount.annotations` |  | `{}` |
+| `serviceAccount.name` |  | `""` |
+| `statefulSet.annotations` |  | `{}` |
+| `service.type` |  | `"ClusterIP"` |
+| `service.port` | The port number that will be used for exposing the PMS port from the service | `32400` |
+| `service.annotations` |  | `{}` |
+| `nodeSelector` |  | `{}` |
+| `tolerations` |  | `[]` |
+| `affinity` |  | `{}` |
+| `commonLabels` | Labels that will be added to all resources created by the chart  | `{}` |
+| `extraEnv` | Environment variables that will be added to the PMS container | `{}` |
+| `extraVolumeMounts` | Additional volume mount configuration blocks for the pms container | `[]` |
+| `extraVolumes` | Extra volume configurations | `[]` |
+| `extraContainers` | Extra contain configuration blocks that will be run alongside the PMS container _after_ the init container finishes | `[]` |
+
+---
+_Documentation generated by [Frigate](https://frigate.readthedocs.io)._

--- a/charts/plex-media-server/templates/NOTES.txt
+++ b/charts/plex-media-server/templates/NOTES.txt
@@ -1,0 +1,12 @@
+Thank you for installing {{ .Chart.Name }}.
+
+Your release is named {{ .Release.Name }}.
+
+To learn more about the release, try:
+
+  $ helm status {{ .Release.Name }}
+  $ helm get all {{ .Release.Name }}
+
+
+Mount path for remote is available at {{ .Values.rclone.path }}
+You can use this as a volume within your other pods to view the file system for your remote.

--- a/charts/plex-media-server/templates/_helpers.tpl
+++ b/charts/plex-media-server/templates/_helpers.tpl
@@ -1,0 +1,123 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "pms-chart.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "pms-chart.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "pms-chart.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+The image to use for pms
+*/}}
+{{- define "pms-chart.image" -}}
+{{- if .Values.image.sha }}
+{{- if .Values.global.imageRegistry }}
+{{- printf "%s/%s:%s@%s" .Values.global.imageRegistry .Values.image.repository (default ("latest") .Values.image.tag) .Values.image.sha }}
+{{- else }}
+{{- printf "%s/%s:%s@%s" .Values.image.registry .Values.image.repository (default ("latest") .Values.image.tag) .Values.image.sha }}
+{{- end }}
+{{- else }}
+{{- if .Values.global.imageRegistry }}
+{{- printf "%s/%s:%s" .Values.global.imageRegistry .Values.image.repository (default ( "latest") .Values.image.tag) }}
+{{- else }}
+{{- printf "%s/%s:%s" .Values.image.registry .Values.image.repository (default ( "latest") .Values.image.tag) }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+The image to use for the init containers
+*/}}
+{{- define "pms-chart.init_image" -}}
+{{- if .Values.initContainer.image.sha }}
+{{- if .Values.global.imageRegistry }}
+{{- printf "%s/%s:%s@%s" .Values.global.imageRegistry .Values.initContainer.image.repository (default ("latest") .Values.initContainer.image.tag) .Values.initContainer.image.sha }}
+{{- else }}
+{{- printf "%s/%s:%s@%s" .Values.initContainer.image.registry .Values.initContainer.image.repository (default ("latest") .Values.initContainer.image.tag) .Values.initContainer.image.sha }}
+{{- end }}
+{{- else }}
+{{- if .Values.global.imageRegistry }}
+{{- printf "%s/%s:%s" .Values.global.imageRegistry .Values.initContainer.image.repository (default ( "latest") .Values.initContainer.image.tag) }}
+{{- else }}
+{{- printf "%s/%s:%s" .Values.initContainer.image.registry .Values.initContainer.image.repository (default ( "latest") .Values.initContainer.image.tag) }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+The image to use for rclone
+*/}}
+{{- define "pms-chart.rclone_image" -}}
+{{- if .Values.rclone.image.sha }}
+{{- if .Values.global.imageRegistry }}
+{{- printf "%s/%s:%s@%s" .Values.global.imageRegistry .Values.rclone.image.repository (default ("latest") .Values.rclone.image.tag) .Values.rclone.image.sha }}
+{{- else }}
+{{- printf "%s/%s:%s@%s" .Values.rclone.image.registry .Values.rclone.image.repository (default ("latest") .Values.rclone.image.tag) .Values.rclone.image.sha }}
+{{- end }}
+{{- else }}
+{{- if .Values.global.imageRegistry }}
+{{- printf "%s/%s:%s" .Values.global.imageRegistry .Values.rclone.image.repository (default ( "latest") .Values.rclone.image.tag) }}
+{{- else }}
+{{- printf "%s/%s:%s" .Values.rclone.image.registry .Values.rclone.image.repository (default ( "latest") .Values.rclone.image.tag) }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "pms-chart.labels" -}}
+app: {{ template "pms-chart.name" . }}
+helm.sh/chart: {{ include "pms-chart.chart" . }}
+{{ include "pms-chart.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- if .Values.commonLabels}}
+{{ toYaml .Values.commonLabels }}
+{{- end }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "pms-chart.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "pms-chart.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "pms-chart.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "pms-chart.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/charts/plex-media-server/templates/configmap-init-script.yaml
+++ b/charts/plex-media-server/templates/configmap-init-script.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.initContainer.script -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name:  {{ include "pms-chart.fullname" . }}-init-script
+  labels:
+{{- include "pms-chart.labels" . | nindent 4 }}
+data:
+  init.sh: |
+{{ .Values.initContainer.script | indent 4 }}
+{{- end -}}

--- a/charts/plex-media-server/templates/ingress.yaml
+++ b/charts/plex-media-server/templates/ingress.yaml
@@ -1,0 +1,32 @@
+{{- if .Values.ingress.enabled -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "pms-chart.fullname" . }}-ingress
+  labels:
+    name: {{ include "pms-chart.fullname" . }}-ingress
+{{ include "pms-chart.labels" . | indent 4 }}
+{{- with .Values.ingress.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
+spec:
+{{- if .Values.ingress.ingressClassName }}
+  ingressClassName: {{ .Values.ingress.ingressClassName }}
+{{- end }}
+  rules:
+  - host: {{ trimPrefix "https://" .Values.ingress.url }}
+    http:
+      paths:
+      - path: '/'
+        pathType: Prefix
+        backend:
+          service:
+            name: {{ include "pms-chart.fullname" . }}
+            port:
+              number: 32400
+  tls:
+  - hosts:
+    - {{ trimPrefix "https://" .Values.ingress.url }}
+    secretName: {{ include "pms-chart.fullname" . }}-ingress-lets-encrypt
+{{- end -}}

--- a/charts/plex-media-server/templates/service.yaml
+++ b/charts/plex-media-server/templates/service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "pms-chart.fullname" . }}
+  labels:
+    {{- include "pms-chart.labels" . | nindent 4 }}
+  {{- with .Values.service.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: 32400
+      protocol: TCP
+      name: pms
+  selector:
+    {{- include "pms-chart.selectorLabels" . | nindent 4 }}

--- a/charts/plex-media-server/templates/serviceaccount.yaml
+++ b/charts/plex-media-server/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "pms-chart.serviceAccountName" . }}
+  labels:
+    {{- include "pms-chart.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
+{{- end }}

--- a/charts/plex-media-server/templates/statefulset.yaml
+++ b/charts/plex-media-server/templates/statefulset.yaml
@@ -171,4 +171,3 @@ spec:
       resources:
         requests:
           storage: {{ .Values.pms.configStorage }}
-

--- a/charts/plex-media-server/templates/statefulset.yaml
+++ b/charts/plex-media-server/templates/statefulset.yaml
@@ -1,0 +1,174 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "pms-chart.fullname" . }}
+  labels:
+    name: {{ include "pms-chart.fullname" . }}
+{{ include "pms-chart.labels" . | indent 4 }}
+  {{- with .Values.statefulSet.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+  {{- end }}
+spec:
+  serviceName: {{ include "pms-chart.fullname" . }}
+  selector:
+    matchLabels:
+      {{- include "pms-chart.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "pms-chart.labels" . | nindent 8 }}
+    spec:
+      volumes:
+      - name: pms-transcode
+        emptyDir: {}
+      {{- if and .Values.rclone.enabled .Values.rclone.configSecret }}
+      {{- range .Values.rclone.remotes }}
+      - name: rclone-media-{{ (split ":" .)._0 }}
+        emptyDir: {}
+      {{- end }}
+      - name: rclone-config
+        emptyDir: {}
+      - name: rclone-config-data
+        secret:
+          secretName: {{ .Values.rclone.configSecret }}
+      {{- end }}
+      {{- if .Values.initContainer.script }}
+      - name: init-script-configmap
+        configMap:
+          defaultMode: 0700
+          name: {{ include "pms-chart.fullname" . }}-init-script
+      {{- end }}
+      {{- if .Values.extraVolumes }}
+{{ toYaml .Values.extraVolumes | indent 6 }}
+      {{- end }}
+    {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+      terminationGracePeriodSeconds: 120
+      initContainers:
+      {{- if .Values.initContainer.script }}
+      - name: {{ include "pms-chart.fullname" . }}-pms-init
+        image: {{ include "pms-chart.init_image" . }}
+        command: ["/init/init.sh"]
+        volumeMounts:
+        - name: pms-config
+          mountPath: /config
+        - name: init-script-configmap
+          mountPath: /init
+      {{- if .Values.extraVolumeMounts }}
+{{ toYaml .Values.extraVolumeMounts | indent 8}}
+      {{- end }}
+      {{- end }}
+      {{- if and .Values.rclone.enabled .Values.rclone.configSecret }}
+      - name: {{ include "pms-chart.fullname" . }}-config
+        image: {{ include "pms-chart.init_image" . }}
+        command:
+          - cp
+        args:
+          - -v
+          - /in/rclone.conf
+          - /out/rclone.conf
+        volumeMounts:
+        - name: rclone-config-data
+          mountPath: /in
+          readOnly: true
+        - name: rclone-config
+          mountPath: /out
+      {{- end }}
+      containers:
+      - name: {{ include "pms-chart.fullname" . }}-pms
+        image: {{ include "pms-chart.image" . }}
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        ports:
+        - containerPort: 32400
+          name: pms
+        env:
+        {{- if .Values.ingress.enabled }}
+        - name: ADVERTISE_IP
+          value: {{ trimPrefix "https://" .Values.ingress.url }}
+        {{- end }}
+        {{- range $key, $value := .Values.extraEnv }}
+        - name: {{ $key }}
+          value: {{ $value }}
+        {{- end }}
+        {{- with .Values.pms.resources }}
+        resources:
+{{ toYaml . | indent 10 }}
+      {{- end }}
+        volumeMounts:
+        - name: pms-config
+          mountPath: /config
+        - name: pms-transcode
+          mountPath: /transcode
+      {{- if and .Values.rclone.enabled .Values.rclone.configSecret }}
+      {{- range .Values.rclone.remotes }}
+        - name: rclone-media-{{ (split ":" .)._0 }}
+          mountPath: "/data/{{ (split ":" .)._0 }}"
+          mountPropagation: HostToContainer
+      {{- end }}
+      {{- end }}
+      {{- if .Values.extraVolumeMounts }}
+{{ toYaml .Values.extraVolumeMounts | indent 8 }}
+      {{- end }}
+    {{- if and .Values.rclone.enabled .Values.rclone.configSecret }}
+    {{- range .Values.rclone.remotes }}
+      - name: {{ include "pms-chart.fullname" $ }}-rclone-{{ (split ":" .)._0 }}
+        image: {{ include "pms-chart.rclone_image" $ }}
+        imagePullPolicy: {{ $.Values.rclone.image.pullPolicy }}
+        args:
+          - mount
+          - "{{ . }}"
+          - "/data/{{ (split ":" .)._0 }}"
+          - --config=/etc/rclone/rclone.conf
+          - --allow-non-empty
+          - --allow-other
+        {{- if $.Values.rclone.readOnly }}
+          - --read-only
+        {{- end }}
+        {{- range $.Values.rclone.additionalArgs }}
+          - {{ . }}
+        {{- end }}
+        {{- with $.Values.rclone.resources }}
+        resources:
+{{ toYaml . | indent 10 }}
+      {{- end }}
+        lifecycle:
+          preStop:
+            exec:
+              command: ["/bin/sh","-c","fusermount -uz /data/{{ (split ":" .)._0 }}"]
+        securityContext:
+          privileged: true
+          capabilities:
+            add:
+              - SYS_ADMIN
+        volumeMounts:
+        - name: rclone-config
+          mountPath: /etc/rclone
+        - name: rclone-media-{{ (split ":" .)._0 }}
+          mountPath: "/data/{{ (split ":" .)._0 }}"
+          mountPropagation: Bidirectional
+      {{- end }}
+      {{- end }}
+      {{- with .Values.extraContainers }}
+{{- toYaml . | nindent 6 }}
+      {{- end }}
+  nodeSelector:
+    {{- toYaml .Values.nodeSelector | nindent 4 }}
+  affinity:
+    {{- toYaml .Values.affinity | nindent 4 }}
+  tolerations:
+    {{- toYaml .Values.tolerations | nindent 4 }}
+  volumeClaimTemplates:
+  - metadata:
+      name: pms-config
+    spec:
+      accessModes: [ "ReadWriteOnce" ]
+      {{- if .Values.pms.storageClassName }}
+      storageClassName: {{ .Values.pms.storageClassName }}
+      {{- end }}
+      resources:
+        requests:
+          storage: {{ .Values.pms.configStorage }}
+

--- a/charts/plex-media-server/values.yaml
+++ b/charts/plex-media-server/values.yaml
@@ -1,0 +1,208 @@
+# Default values for pms-chart.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+# The docker image information for the pms application
+
+image:
+  registry: index.docker.io
+  repository: plexinc/pms-docker
+  # If unset use "latest"
+  tag: "latest"
+  sha: ""
+  pullPolicy: IfNotPresent
+
+global:
+  # Allow parent charts to override registry hostname
+  imageRegistry: ""
+
+ingress:
+  # Specify if an ingress resource for the pms server should be created or not
+  enabled: false
+
+  # The ingress class that should be used
+  ingressClassName: "ingress-nginx"
+
+  # The url to use for the ingress reverse proxy to point at this pms instance
+  url: ""
+
+  # Custom annotations to put on the ingress resource
+  annotations: {}
+
+pms:
+  # The storage class to use when provisioning the pms config volume
+  # this needs to be created manually, null will use the default
+  storageClassName: null
+
+  # the volume size to provision for the PMS database
+  configStorage: 2Gi
+
+  resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+
+# A basic image that will convert the configmap to a file in the rclone config volume
+# this is ignored if rclone is not enabled
+initContainer:
+  image:
+    registry: index.docker.io
+    repository: alpine
+    # If unset use latest
+    tag: 3.18.0
+    sha: ""
+    pullPolicy: IfNotPresent
+
+  # A custom script that will be run in an init container to do any setup before the PMS service starts up
+  # This will be run everytime the pod starts, make sure that some mechanism is included to prevent
+  # this from running more than once if it should only be run on the first startup.
+  script: ""
+  ###
+  ### Example init script that will import a pre-existing pms database if one has not already been setup
+  ### This pms database must be available through a URL (or some other mechanism to be pulled into the container)
+  # script: |-
+  #   #!/bin/sh
+  #   echo "fetching pre-existing pms database to import..."
+  #
+  #   if [ -d "/config/Library" ]; then
+  #     echo "PMS library already exists, exiting."
+  #     exit 0
+  #   fi
+  #
+  #   apk --update add curl
+  #   curl http://example.com/pms.tgz -o pms.tgz
+  #   tar -xvzf pms.tgz -C /config
+  #   cp -r /config/data/Library /config/Library
+  #   rm -rf /config/data pms.tgz
+  #
+  #   echo "Done."
+
+# the settings specific to rclone
+rclone:
+  # if the rclone sidecar should be created
+  enabled: false
+
+  # the rclone image that should be used
+  image:
+    registry: index.docker.io
+    repository: rclone/rclone
+    # If unset use latest
+    tag: 1.62.2
+    sha: ""
+    pullPolicy: IfNotPresent
+
+  # The name of the secret that contains the rclone configuration file.
+  # The key must be called `rclone.conf` in the secret
+  configSecret: ""
+
+
+  # the remote drive that should be mounted using rclone
+  # this must be in the form of `name:[/optional/path]`
+  # this remote will be mounted at `/data/name` in the PMS container
+  remotes: []
+
+  # if the remote volumes should be mounted as read only
+  readOnly: true
+
+  # additional arguments to give to rclone when mounting the volume
+  additionalArgs: []
+
+  resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # If the service account token should be auto mounted
+  automountServiceAccountToken: false
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
+statefulSet:
+  # optional extra annotations to add to the service resource
+  annotations: {}
+
+service:
+  type: ClusterIP
+  port: 32400
+
+  # optional extra annotations to add to the service resource
+  annotations: {}
+
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+
+# Common Labels for all resources created by this chart.
+commonLabels: {}
+
+extraEnv: {}
+# extraEnv:
+  # This claim is optional, and is only used for the first startup of PMS
+  # The claim is obtained from https://www.plex.tv/claim/ is is only valid for a few minutes
+#   PLEX_CLAIM: "claim"
+#   HOSTNAME: "PlexServer"
+#   TZ: "Etc/UTC"
+#   PLEX_UPDATE_CHANNEL: "5"
+#   PLEX_UID: "uid of plex user"
+#   PLEX_GID: "group id of plex user"
+  # a list of CIDRs that can use the server without authentication
+  # this is only used for the first startup of PMS
+#   ALLOWED_NETWORKS: "0.0.0.0/0"
+
+
+# Optionally specify additional volume mounts for the PMS and init containers.
+extraVolumeMounts: []
+# extraVolumeMounts:
+#   - name: some-volume-name
+#     mountPath: /path/in/container
+
+
+# Optionally specify additional volumes for the pod.
+extraVolumes: []
+# extraVolumes:
+#   - name: some-volume-name
+#     emptyDir: {}
+
+extraContainers: []
+# extraContainers:
+#  - name: <container name>
+#    args:
+#      - ...
+#    image: <docker images>
+#    imagePullPolicy: IfNotPresent
+#    resources:
+#      limits:
+#        memory: 128Mi
+#      requests:
+#        cpu: 100m
+#        memory: 128Mi
+#    volumeMounts:
+#      - ...


### PR DESCRIPTION
closes: https://github.com/plexinc/operations/issues/2886

Adds a new method to deploy a PMS container to a Kubernetes cluster. 

This chart will deploy a `StatefulSet` with a single instance of of PMS.
Data volumes can be mounted by creating `PersistentVolume`s or by using the `rclone` sidecars to be able to easily mount drives from arbitrary locations that may not have Kubernetes drivers.

By default this chart will create a PMS service _internal_ to the cluster that is published on the standard PMS port.
However, this will now allow direct external connections to PMS. 
A builtin ingress controller has been provided that will allow PMS to be accessed over the standard HTTP(s) ports, this will require manually reconfiguring the PMS instance to [advertise using this url](https://support.plex.tv/articles/200430283-network/). 