### PR TITLE
feat: add a workflow to package and release the helm chart

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+charts/** @plexinc/team-operations

--- a/.github/workflows/helm.yaml
+++ b/.github/workflows/helm.yaml
@@ -4,7 +4,8 @@ on:
   push:
     branches:
       - master
-
+    paths:
+      - 'charts/**'
 permissions:
   contents: read
 

--- a/.github/workflows/helm.yaml
+++ b/.github/workflows/helm.yaml
@@ -1,0 +1,82 @@
+name: Helm
+
+on:
+  push:
+    branches:
+      - master
+
+permissions:
+  contents: read
+
+jobs:
+
+  changes:
+    permissions:
+      contents: read  # for dorny/paths-filter to fetch a list of changed files
+      pull-requests: read  # for dorny/paths-filter to read pull requests
+    runs-on: ubuntu-latest
+    if: |
+      (github.repository == 'plexinc/pms-docker')
+    outputs:
+      docs: ${{ steps.filter.outputs.docs }}
+      charts: ${{ steps.filter.outputs.charts }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+
+      - name: Run Artifact Hub lint
+        run: |
+          wget https://github.com/artifacthub/hub/releases/download/v1.5.0/ah_1.5.0_linux_amd64.tar.gz
+          echo 'ad0e44c6ea058ab6b85dbf582e88bad9fdbc64ded0d1dd4edbac65133e5c87da *ah_1.5.0_linux_amd64.tar.gz' | shasum -c
+          tar -xzvf ah_1.5.0_linux_amd64.tar.gz ah
+          ./ah lint -p charts/plex-media-server || exit 1
+          rm -f ./ah ./ah_1.5.0_linux_amd64.tar.gz
+
+      - name: Lint
+        run: |
+          ./build/run-in-docker.sh ./hack/verify-chart-lint.sh
+
+      - uses: dorny/paths-filter@4512585405083f25c027a35db413c2b3b9006d50 # v2.11.1
+        id: filter
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          filters: |
+            charts:
+              - 'charts/plex-media-server/Chart.yaml'
+              - 'charts/plex-media-server/values.yaml'
+
+  chart:
+    name: Release Chart
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write # needed to write releases
+
+    needs:
+      - changes
+    if: |
+      (github.repository == 'plexinc/pms-docker') &&
+      (needs.changes.outputs.charts == 'true')
+
+    steps:
+      - name: Checkout master
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+        with:
+          # Fetch entire history. Required for chart-releaser; see https://github.com/helm/chart-releaser-action/issues/13#issuecomment-602063896
+          fetch-depth: 0
+
+      - name: Setup
+        shell: bash
+        run: |
+          git config --global user.name "$GITHUB_ACTOR"
+          git config --global user.email "$GITHUB_ACTOR@users.noreply.github.com"
+
+      - name: Helm Chart Releaser
+        uses: helm/chart-releaser-action@be16258da8010256c6e82849661221415f031968 # v1.5.0
+        env:
+          CR_SKIP_EXISTING: "false"
+          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          CR_RELEASE_NAME_TEMPLATE: "helm-chart-{{ .Version }}"
+        with:
+          charts_dir: charts


### PR DESCRIPTION
In #82 a helm chart was added but it is not currently installable directly from helm without being packaged properly. 
This adds a github workflow that will automatically package and publish the chart using github pages. This workflow was modified from the one used by [ingress-nginx](https://github.com/kubernetes/ingress-nginx/blob/main/.github/workflows/helm.yaml)


Steps that are still needed:
- [ ] @lotooo create and set a `GITHUB_TOKEN` secret for this git repository
- [x] Create a `gh-pages` branch to store the artifacts
- [ ] enable github pages using the `gh-pages` branch on this repository