### PR TITLE
fix: the tolerations block was at the wrong level in the statefulset

### DIFF
--- a/charts/plex-media-server/Chart.yaml
+++ b/charts/plex-media-server/Chart.yaml
@@ -22,7 +22,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 0.1.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/plex-media-server/templates/statefulset.yaml
+++ b/charts/plex-media-server/templates/statefulset.yaml
@@ -19,6 +19,12 @@ spec:
       labels:
         {{- include "pms-chart.labels" . | nindent 8 }}
     spec:
+      tolerations:
+      {{- toYaml .Values.tolerations | nindent 6 }}
+      nodeSelector:
+      {{- toYaml .Values.nodeSelector | nindent 6 }}
+      affinity:
+      {{- toYaml .Values.affinity | nindent 6 }}
       volumes:
       - name: pms-transcode
         emptyDir: {}
@@ -154,12 +160,6 @@ spec:
       {{- with .Values.extraContainers }}
 {{- toYaml . | nindent 6 }}
       {{- end }}
-  nodeSelector:
-    {{- toYaml .Values.nodeSelector | nindent 4 }}
-  affinity:
-    {{- toYaml .Values.affinity | nindent 4 }}
-  tolerations:
-    {{- toYaml .Values.tolerations | nindent 4 }}
   volumeClaimTemplates:
   - metadata:
       name: pms-config


### PR DESCRIPTION
This fixes the problem where the tolerations were at the `.spec.tolerations` level but should have been at `.spec.template.spec.tolerations`

This will be released as a patch version bump of the chart
