### PR TITLE
build: add chart-testing workflow

### DIFF
--- a/.github/linters/ct.yaml
+++ b/.github/linters/ct.yaml
@@ -1,0 +1,4 @@
+chart-dirs:
+- charts
+helm-extra-args: --timeout 300s
+validate-maintainers: false

--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -1,0 +1,49 @@
+name: Lint and Test Charts
+
+# yamllint disable-line rule:truthy
+on:
+  workflow_call:
+  workflow_dispatch:
+  pull_request:
+    paths:
+    - 'charts/**'
+
+jobs:
+  lint-test:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+
+    - name: Set up Helm
+      uses: azure/setup-helm@v3
+      with:
+        version: v3.13.1
+
+    - uses: actions/setup-python@v4
+      with:
+        python-version: 3.x
+        check-latest: true
+
+    - name: Set up chart-testing
+      uses: helm/chart-testing-action@v2
+
+    - name: Run chart-testing (list-changed)
+      id: list-changed
+      run: |
+        changed=$(ct list-changed --config .github/linters/ct.yaml)
+        if [[ -n "$changed" ]]; then
+          echo "changed=true" >> "$GITHUB_OUTPUT"
+        fi
+
+    - name: Run chart-testing (lint)
+      run: ct lint --config .github/linters/ct.yaml
+
+    - name: Create kind cluster
+      uses: helm/kind-action@v1
+      if: steps.list-changed.outputs.changed == 'true'
+
+    - name: Run chart-testing (install)
+      run: ct install --config ct.yaml


### PR DESCRIPTION
Add a `ct` job to lint and test charts using helm/chart-testing. By default, any PRs that modify `charts/*` will be linted and the chart installed against a kind cluster to check for correctness. 