### PR TITLE
When providing the UID or GID as a number the chart fails to deploy, …

### DIFF
--- a/charts/plex-media-server/Chart.yaml
+++ b/charts/plex-media-server/Chart.yaml
@@ -22,7 +22,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.6
+version: 0.1.7
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/plex-media-server/templates/statefulset.yaml
+++ b/charts/plex-media-server/templates/statefulset.yaml
@@ -101,7 +101,7 @@ spec:
         {{- end }}
         {{- range $key, $value := .Values.extraEnv }}
         - name: {{ $key }}
-          value: {{ $value }}
+          value: {{ $value | quote }}
         {{- end }}
         {{- with .Values.pms.resources }}
         resources:


### PR DESCRIPTION
I did not see a contributing.md before opening this PR, if there are steps I've missed please let me know.

Problem: When specifying the gid (`PLEX_GID`) or uid (`PLEX_UID`) as numeric values under extraEnv helm fails to deploy because the options are provided as integers instead of strings, regardless of how the values are provided within the values.yaml. For example all of these will fail to deploy
```
extraEnv:
  PLEX_UID: '1000'
  PLEX_GID: "1000"
  OTHER_ENVVAR: 1000
```

Error Message:
```
json: cannot unmarshal number into Go struct field EnvVar.spec.template.spec.containers.env.value of type string
```


Potential Solution: I've added quotations around the key/value pair that are land the env vars, if there is a more preferable solution I can update the pull request to accommodate. I've tested this solution works for me on my cluster.
