### PR TITLE
build: fix ct lint steps

### DIFF
--- a/.github/linters/ct.yaml
+++ b/.github/linters/ct.yaml
@@ -1,4 +1,3 @@
 chart-dirs:
 - charts
-helm-extra-args: --timeout 300s
 validate-maintainers: false


### PR DESCRIPTION
Helm argument is redundant during lint and fails the checks.