### PR TITLE
Helm chart: Define port for NodePort

### DIFF
--- a/charts/plex-media-server/templates/service.yaml
+++ b/charts/plex-media-server/templates/service.yaml
@@ -13,6 +13,9 @@ spec:
   ports:
     - port: {{ .Values.service.port }}
       targetPort: 32400
+      {{- if eq .Values.service.type "NodePort" }}
+      nodePort: {{ default "32400" .Values.service.nodePort }}
+      {{- end }}
       protocol: TCP
       name: pms
   selector:

--- a/charts/plex-media-server/values.yaml
+++ b/charts/plex-media-server/values.yaml
@@ -144,6 +144,9 @@ service:
   type: ClusterIP
   port: 32400
 
+  # Port to use when type of service is "NodePort" (32400 by default)
+  #nodePort: 32400
+
   # optional extra annotations to add to the service resource
   annotations: {}
 


### PR DESCRIPTION
# Initial problem

When installing the chart on my microk8s cluster, I use NodePort to make Plex accessible from internet. But, the port is randomly defined, and can change at any time.

# This PR Solution

Add the ability to define the node port to use when service is NodePort. Default is 32400.

- When service = NodePort, the nodePort will automatically be 32400 by default.
- If user want to override and define is own node port, he can define the `.Value.service.nodePort` value to whatever he want