### PR TITLE
Helm chart: Add the ability to use a pre existing peristent volume claim

### DIFF
--- a/charts/plex-media-server/Chart.yaml
+++ b/charts/plex-media-server/Chart.yaml
@@ -22,7 +22,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.0
+version: 0.2.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/plex-media-server/templates/statefulset.yaml
+++ b/charts/plex-media-server/templates/statefulset.yaml
@@ -30,6 +30,11 @@ spec:
       priorityClassName: {{ .Values.priorityClassName | quote }}
       {{- end }}
       volumes:
+      {{- if .Values.pms.configExistingClaim }}
+      - name: pms-config
+        persistentVolumeClaim:
+          claimName: {{ .Values.pms.configExistingClaim | quote }}
+      {{- end }}
       - name: pms-transcode
         emptyDir: {}
       {{- if and .Values.rclone.enabled .Values.rclone.configSecret }}
@@ -164,6 +169,7 @@ spec:
       {{- with .Values.extraContainers }}
 {{- toYaml . | nindent 6 }}
       {{- end }}
+  {{- if not .Values.pms.configExistingClaim }}
   volumeClaimTemplates:
   - metadata:
       name: pms-config
@@ -175,3 +181,4 @@ spec:
       resources:
         requests:
           storage: {{ .Values.pms.configStorage }}
+  {{- end }}

--- a/charts/plex-media-server/values.yaml
+++ b/charts/plex-media-server/values.yaml
@@ -32,6 +32,10 @@ pms:
   # the volume size to provision for the PMS database
   configStorage: 2Gi
 
+  # Name of an existing `PersistentVolumeClaim` for the PMS database
+  # NOTE: When set, 'configStorage' and 'storageClassName' are ignored.
+  configExistingClaim: ""
+
   resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little


### PR DESCRIPTION
# Problem
I have an existing persistent volume and persistent volume claim with my PMS database. I want to use this pvc with the PMS helm chart.

# Solution
This PR uses a common helm pattern where the user can provide the name of a pre existing volume claim and the chart will configure the PMS container to use that claim instead of creating a volumeClaimTemplate.