### PR TITLE
feat: allow setting pod annotations

### DIFF
--- a/charts/plex-media-server/Chart.yaml
+++ b/charts/plex-media-server/Chart.yaml
@@ -22,7 +22,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.1
+version: 0.3.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/plex-media-server/templates/statefulset.yaml
+++ b/charts/plex-media-server/templates/statefulset.yaml
@@ -18,6 +18,8 @@ spec:
     metadata:
       labels:
         {{- include "pms-chart.labels" . | nindent 8 }}
+      annotations:
+        {{- toYaml .Values.statefulSet.podAnnotations | nindent 8 }}
     spec:
       serviceAccountName: {{ include "pms-chart.serviceAccountName" . }}
       tolerations:

--- a/charts/plex-media-server/values.yaml
+++ b/charts/plex-media-server/values.yaml
@@ -143,6 +143,8 @@ serviceAccount:
 statefulSet:
   # optional extra annotations to add to the service resource
   annotations: {}
+  # optional extra annotations to add to the pods in the statefulset
+  podAnnotations: {}
 
 service:
   type: ClusterIP


### PR DESCRIPTION
Currently there is no way to annotate the pods in PMS' StatefulSet. This adds a chart value to do precisely that. My use case is that I want to add Plex to my Linkerd service mesh, which can be done through the `linkerd.io/inject` annotation.
