### PR TITLE
Add runtimeClassName

### DIFF
--- a/charts/plex-media-server/Chart.yaml
+++ b/charts/plex-media-server/Chart.yaml
@@ -22,7 +22,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.0
+version: 0.4.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/plex-media-server/README.md
+++ b/charts/plex-media-server/README.md
@@ -113,6 +113,7 @@ The following table lists the configurable parameters of the Pms-chart chart and
 | `initContainer.image.sha` | Optional SHA digest to specify a specific image rather than a specific tag | `""` |
 | `initContainer.image.pullPolicy` |  | `"IfNotPresent"` |
 | `initContainer.script` | An optional script that will be run by the init container, it can be used on the first run to stop pms from starting when importing a pre-exiting database | `""` |
+| `runtimeClassName` | Specify your own runtime class name eg use gpu | `""` |
 | `rclone.enabled` | If rclone should be used to mount volumes | `false` |
 | `rclone.image.registry` | The registry that should be used to pull the image from | `"index.docker.io"` |
 | `rclone.image.repository` | The docker repo that will be used for the rclone container | `"rclone/rclone"` |

--- a/charts/plex-media-server/templates/statefulset.yaml
+++ b/charts/plex-media-server/templates/statefulset.yaml
@@ -21,6 +21,9 @@ spec:
       annotations:
         {{- toYaml .Values.statefulSet.podAnnotations | nindent 8 }}
     spec:
+      {{- if .Values.runtimeClassName }}
+      runtimeClassName: {{ .Values.runtimeClassName | quote }}
+      {{- end }}
       serviceAccountName: {{ include "pms-chart.serviceAccountName" . }}
       tolerations:
         {{- toYaml .Values.tolerations | nindent 8 }}

--- a/charts/plex-media-server/values.yaml
+++ b/charts/plex-media-server/values.yaml
@@ -83,6 +83,9 @@ initContainer:
   #
   #   echo "Done."
 
+# specify your own runtime class name eg use gpu
+runtimeClassName: "" 
+
 # the settings specific to rclone
 rclone:
   # if the rclone sidecar should be created

--- a/charts/plex-media-server/values.yaml
+++ b/charts/plex-media-server/values.yaml
@@ -84,7 +84,7 @@ initContainer:
   #   echo "Done."
 
 # specify your own runtime class name eg use gpu
-runtimeClassName: "" 
+runtimeClassName: ""
 
 # the settings specific to rclone
 rclone:


### PR DESCRIPTION
This option might be interesting for those that are running a GPU within their kubernetes cluster and want to be able to specify the runtimeClassName manually.

```
---
apiVersion: v1
kind: Pod
metadata:
  name: nbody-gpu-benchmark
  namespace: default
spec:
  restartPolicy: OnFailure
  runtimeClassName: nvidia
  containers:
  - name: cuda-container
    image: nvcr.io/nvidia/k8s/cuda-sample:nbody
    args: ["nbody", "-gpu", "-benchmark"]
    resources:
      limits:
        nvidia.com/gpu: 1
    env:
    - name: NVIDIA_VISIBLE_DEVICES
      value: all
    - name: NVIDIA_DRIVER_CAPABILITIES
      value: all
```