### PR TITLE
Fix arm64 plex build string

### DIFF
--- a/root/installBinary.sh
+++ b/root/installBinary.sh
@@ -8,7 +8,7 @@ if [ "${TARGETPLATFORM}" = 'linux/arm/v7' ]; then
 elif [ "${TARGETARCH}" = 'amd64' ]; then
   PLEX_BUILD='linux-x86_64';
 elif [ "${TARGETARCH}" = 'arm64' ]; then
-  PLEX_BUILD='aarch64' ;
+  PLEX_BUILD='linux-aarch64' ;
 fi
 
 addVarToConf "version" "${TAG}"


### PR DESCRIPTION
Fix bug injected into #107 that altered the `PLEX_BUILD` variable causing arm64 docker builds to fail to find arm64 images on the plex download server.

```
 $ docker build --platform linux/arm64 --no-cache -t plexinc/pms-docker:latest .
Sending build context to Docker daemon  152.1kB
Step 1/20 : FROM ubuntu:20.04
.
.
.
Step 19/20 : RUN /installBinary.sh
 ---> Running in 3af3d168a359
Could not get install version
The command '/bin/sh -c /installBinary.sh' returned a non-zero code: 1
```

Here is the original `PLEX_BUILD` which was correct:
https://github.com/plexinc/pms-docker/blob/4d069dc46541f535a6d40fb4e26744fd69060bac/Dockerfile.arm64#L5


```
$ curl -w '%{http_code}' "https://plex.tv/downloads/details/5?build=aarch64&channel=8&distro=debian"
404
```
vs.
```
$ curl -w '%{http_code}' "https://plex.tv/downloads/details/5?build=linux-aarch64&channel=8&distro=debian"
<?xml version="1.0" encoding="UTF-8"?>
<MediaContainer friendlyName="myPlex" identifier="com.plexapp.plugins.myplex" size="1" title="Download details">
  <Release id="5568" version="1.40.5.8854-f36c552fd" added="(Log) Reduced the number of log messages generated when starting playback on an NVIDIA device. (PM-1417)&#10;(Windows) noautorestart command line parameter added which prevents PMS from restarting after an auto update (PM-1305)" fixed="(Analysis) Preview thumbnail generation would not run on newly added media regardless if the preference was set (PM-1782)&#10;(Lyrics) Sidecar lyrics would fail to load (PM-1865)&#10;(QNAP) PMS might not start in all cases after QTS/QuTS restart.&#10;(View State Sync) Item plays could be duplicated when state synced from service.&#10;(Windows 64bit) Not all files were removed on uninstall (PM-1632)&#10;Plex Media Server could crash when falling back to SW encoding. (#15026)" live="1" autoupdate="1" createdAt="2024-08-13 12:54:19 UTC">
    <Package manifest="/updater/packages/201869/manifest" manifestHash="" manifestHashSha256="" file="/updater/packages/201869/file" fileHash="ca1518b91efeea77de51bbc5cae651fda9850cc6" fileHashSha256="4cf95ca0623fdd87d92ca100d32d9824ea49e7ffcee3845c7af429631c21702b" fileName="plexmediaserver_1.40.5.8854-f36c552fd_arm64.deb" delta="0" url="https://downloads.plex.tv/plex-media-server-new/1.40.5.8854-f36c552fd/debian/plexmediaserver_1.40.5.8854-f36c552fd_arm64.deb"/>
  </Release>
</MediaContainer>
200
```

