### PR TITLE
Add simple GPU support and improve rclone secret usage in Helm chart

### DIFF
--- a/charts/plex-media-server/templates/statefulset.yaml
+++ b/charts/plex-media-server/templates/statefulset.yaml
@@ -59,6 +59,12 @@ spec:
           defaultMode: 0700
           name: {{ include "pms-chart.fullname" . }}-init-script
       {{- end }}
+      {{- if .Values.pms.gpu.nvidia.enabled }}
+      - name: nvidia
+        hostPath:
+          path: {{ .Values.pms.gpu.nvidia.device | default "/dev/nvidia0" }}
+          type: CharDevice
+      {{- end }}
       {{- if .Values.extraVolumes }}
 {{ toYaml .Values.extraVolumes | indent 6 }}
       {{- end }}
@@ -85,11 +91,10 @@ spec:
       - name: {{ include "pms-chart.fullname" . }}-config
         image: {{ include "pms-chart.init_image" . }}
         command:
-          - cp
+          - sh
+          - -c
         args:
-          - -v
-          - /in/rclone.conf
-          - /out/rclone.conf
+          - cp -v /in/* /out/
         volumeMounts:
         - name: rclone-config-data
           mountPath: /in
@@ -113,10 +118,26 @@ spec:
         - name: {{ $key }}
           value: {{ $value | quote }}
         {{- end }}
+        {{- if .Values.pms.gpu.nvidia.enabled }}
+        - name: NVIDIA_VISIBLE_DEVICES
+          value: all
+        - name: NVIDIA_DRIVER_CAPABILITIES
+          value: compute,video,utility
+        {{- end }}
         {{- with .Values.pms.resources }}
         resources:
-{{ toYaml . | indent 10 }}
-      {{- end }}
+          limits:
+          {{- with .limits }}
+            {{ toYaml . | indent 12 | trim }}
+          {{- end }}
+          {{- if and $.Values.pms.gpu.nvidia.enabled (not (hasKey .limits "nvidia.com/gpu")) }}
+            nvidia.com/gpu: 1
+          {{- end }}
+          {{- if .requests }}
+          requests:
+            {{ toYaml .requests | indent 12 | trim }}
+          {{- end }}
+        {{- end }}
         volumeMounts:
         - name: pms-config
           mountPath: /config
@@ -128,6 +149,10 @@ spec:
           mountPath: "/data/{{ (split ":" .)._0 }}"
           mountPropagation: HostToContainer
       {{- end }}
+      {{- end }}
+      {{- if .Values.pms.gpu.nvidia.enabled }}
+        - name: nvidia
+          mountPath: {{ .Values.pms.gpu.nvidia.device | default "/dev/nvidia0" }}
       {{- end }}
       {{- if .Values.extraVolumeMounts }}
 {{ toYaml .Values.extraVolumeMounts | indent 8 }}
@@ -164,7 +189,7 @@ spec:
             add:
               - SYS_ADMIN
         volumeMounts:
-        - name: rclone-config
+        - name: rclone-config-data
           mountPath: /etc/rclone
         - name: rclone-media-{{ (split ":" .)._0 }}
           mountPath: "/data/{{ (split ":" .)._0 }}"

--- a/charts/plex-media-server/values.yaml
+++ b/charts/plex-media-server/values.yaml
@@ -200,15 +200,16 @@ extraEnv: {}
 # Optionally specify additional volume mounts for the PMS and init containers.
 extraVolumeMounts: []
 # extraVolumeMounts:
-#   - name: some-volume-name
-#     mountPath: /path/in/container
-
+#   - name: dev-dri
+#     mountPath: /dev/dri
 
 # Optionally specify additional volumes for the pod.
 extraVolumes: []
 # extraVolumes:
-#   - name: some-volume-name
-#     emptyDir: {}
+#   - name: dev-dri
+#     hostPath:
+#       path: /dev/dri
+#       type: Directory
 
 extraContainers: []
 # extraContainers:

--- a/charts/plex-media-server/values.yaml
+++ b/charts/plex-media-server/values.yaml
@@ -36,6 +36,14 @@ pms:
   # NOTE: When set, 'configStorage' and 'storageClassName' are ignored.
   configExistingClaim: ""
 
+  # Enabling this will add nvidia.com/gpu: 1 to limits, will set
+  # environment for the nvidia operator, and will mount {device} into
+  # the container (default /dev/nvidia0)
+  gpu:
+    nvidia:
+      enabled: false
+      # device: /dev/nvidia0
+
   resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little
@@ -101,7 +109,10 @@ rclone:
     pullPolicy: IfNotPresent
 
   # The name of the secret that contains the rclone configuration file.
-  # The key must be called `rclone.conf` in the secret
+  # The rclone config key must be called `rclone.conf` in the secret
+  #
+  # All keys in configSecret will be available in /etc/rclone/. This might
+  # be useful if other files are needed, such as a private key for sftp mode.
   configSecret: ""
 
 


### PR DESCRIPTION
This PR primarily provides a simple way for enabling support for an Nvidia GPU in Kubernetes. Additionally, it copies all keys from the rclone secret into /etc/rclone, which is useful if you want to ship credentials or other files, such as a private key for rclone via sftp.

The values.yaml interface for enabling GPU support is in these keys:

```yaml
pms:
  # Enabling this will add nvidia.com/gpu: 1 to limits, will set
  # environment for the nvidia operator, and will mount {device} into
  # the container (default /dev/nvidia0)
  gpu:
    nvidia:
      enabled: false
      # device: /dev/nvidia0
```

Additionally the config init container command and args are modified to copy all secret keys into the config-data mount, and more useful extraVolumes / extraVolumeMounts comments were added for `/dev/dri` specifically as it is likely to be common for plex.

Updates to the README were not made, I'm guessing helm docs are done via pipeline.