### PR TITLE
added externalTrafficPolicy to service

### DIFF
--- a/charts/plex-media-server/Chart.yaml
+++ b/charts/plex-media-server/Chart.yaml
@@ -22,7 +22,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.5.0
+version: 0.6.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/plex-media-server/templates/service.yaml
+++ b/charts/plex-media-server/templates/service.yaml
@@ -10,6 +10,9 @@ metadata:
   {{- end }}
 spec:
   type: {{ .Values.service.type }}
+  {{- if .Values.service.externalTrafficPolicy }}
+  externalTrafficPolicy: {{ .Values.service.externalTrafficPolicy }}
+  {{- end }}
   ports:
     - port: {{ .Values.service.port }}
       targetPort: 32400

--- a/charts/plex-media-server/values.yaml
+++ b/charts/plex-media-server/values.yaml
@@ -165,6 +165,15 @@ service:
   # Port to use when type of service is "NodePort" (32400 by default)
   # nodePort: 32400
 
+  # when NodePort is used, plex is unable to determine user IP
+  # all traffic seems to come from within the cluster
+  # setting this to 'Local' will allow Plex to determine the actual IP of user.
+  # used to determine bitrate for remote transcoding
+  # but the pods can only be accessed by the Node IP where the pod is running
+  # Read more here: https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip
+  # https://access.redhat.com/solutions/7028639
+  # externalTrafficPolicy: Local
+
   # optional extra annotations to add to the service resource
   annotations: {}
 


### PR DESCRIPTION
 When NodePort is used, plex container is unable to determine the user IP because k8s does NAT.
Because of this, all traffic seems to originate from the cluster itself.
This breaks a bunch of plex functionalities like determining bitrate for transcode and many other that rely on determining if the user is in LAN or WAN.
Setting `externalTrafficPolicy: Local` will allow Plex to determine the actual IP of user because this disables k8s NAT.
But this setting comes with caveats: the pods can only be accessed by the specific Node IP where the pod is running.

Read more here: 
https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip
https://access.redhat.com/solutions/7028639

This is my first time contributing, please let me know if there is specific branching requirements. I could not find any guidelines to contributing. Thanks!