### PR TITLE
Fix incorrect nesting of liveness and readiness probes

### DIFF
--- a/charts/plex-media-server/Chart.yaml
+++ b/charts/plex-media-server/Chart.yaml
@@ -22,7 +22,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.7.0
+version: 0.7.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/plex-media-server/templates/statefulset.yaml
+++ b/charts/plex-media-server/templates/statefulset.yaml
@@ -118,10 +118,14 @@ spec:
         - name: NVIDIA_DRIVER_CAPABILITIES
           value: compute,video,utility
         {{- end }}
+        {{- with .Values.pms.livenessProbe }}
         livenessProbe:
-          {{- toYaml .Values.pms.livenessProbe | nindent 10 }}
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+        {{- with .Values.pms.readinessProbe }}
         readinessProbe:
-          {{- toYaml .Values.pms.readinessProbe | nindent 10 }}
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
         {{- with .Values.pms.resources }}
         resources:
           limits:

--- a/charts/plex-media-server/templates/statefulset.yaml
+++ b/charts/plex-media-server/templates/statefulset.yaml
@@ -118,11 +118,11 @@ spec:
         - name: NVIDIA_DRIVER_CAPABILITIES
           value: compute,video,utility
         {{- end }}
-        {{- with .Values.pms.resources }}
         livenessProbe:
           {{- toYaml .Values.pms.livenessProbe | nindent 10 }}
         readinessProbe:
           {{- toYaml .Values.pms.readinessProbe | nindent 10 }}
+        {{- with .Values.pms.resources }}
         resources:
           limits:
           {{- with .limits }}


### PR DESCRIPTION
Liveness and readiness probes introduced in #117 are incorrectly nested within the `resources` template. Adding resource limits to the pms chart results in the following error:

```
Error: template: plex-media-server/templates/statefulset.yaml:123:28: executing "plex-media-server/templates/statefulset.yaml" at <.Values.pms.livenessProbe>: nil pointer evaluating interface {}.pms
```

This change fixes that issue.