### PR TITLE
Add ingress secret name variable in helm chart

### DIFF
--- a/charts/plex-media-server/Chart.yaml
+++ b/charts/plex-media-server/Chart.yaml
@@ -22,7 +22,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.7.2
+version: 0.7.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/plex-media-server/Chart.yaml
+++ b/charts/plex-media-server/Chart.yaml
@@ -22,7 +22,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.7.3
+version: 0.8.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/plex-media-server/templates/ingress.yaml
+++ b/charts/plex-media-server/templates/ingress.yaml
@@ -28,5 +28,5 @@ spec:
   tls:
   - hosts:
     - {{ trimPrefix "https://" .Values.ingress.url }}
-    secretName: {{ include "pms-chart.fullname" . }}-ingress-lets-encrypt
+    secretName: {{ .Values.ingress.certificateSecret | default (printf "%s-ingress-lets-encrypt" (include "pms-chart.fullname" .)) }}
 {{- end -}}

--- a/charts/plex-media-server/values.yaml
+++ b/charts/plex-media-server/values.yaml
@@ -22,6 +22,10 @@ ingress:
   # -- The url to use for the ingress reverse proxy to point at this pms instance
   url: ""
 
+  # -- Optional secret name to provide valid https connections
+  # using an existing SSL certificate
+  certificateSecret: ""
+
   # -- Custom annotations to put on the ingress resource
   annotations: {}
 


### PR DESCRIPTION
By default, the `Ingress` object uses a SSL secret called:

```yaml
{{ include "pms-chart.fullname" . }}-ingress-lets-encrypt
```

Which cannot be customized, as it uses the helm chart name and a suffix `-ingress-lets-encrypt` 🥲

This PR adds an optional variable to the Helm Chart called `ingress.certificateSecret`, to specify that SSL secret name.

By default, this variable has a blank `""` value. If we render the Chart using this default value, the result will be exactly the same as the current value:

```yaml
default (printf "%s-ingress-lets-encrypt" (include "pms-chart.fullname" .))
```
Which is equivalent to:

```yaml
{{ include "pms-chart.fullname" . }}-ingress-lets-encrypt
```

On the other hand, if we specify a string value different from `""`:

```yaml
# values.yaml
ingress:
  enabled: true
  # . . .
  certificateSecret: "my-custom-ssl-certificate"
```

The SSL `secretName` will use the variable as the name when rendering the Chart:

```yaml
# Ingress object
tls:
  - hosts:
    - https://sample.com
    secretName: my-custom-ssl-certificate
```
