### PR TITLE
Add support for extra init containers and sidecar containers

### DIFF
--- a/charts/plex-media-server/templates/statefulset.yaml
+++ b/charts/plex-media-server/templates/statefulset.yaml
@@ -96,6 +96,9 @@ spec:
         - name: rclone-config
           mountPath: /out
       {{- end }}
+      {{- with .Values.extraInitContainers }}
+{{- toYaml . | nindent 6 }}
+      {{- end }}
       containers:
       - name: {{ include "pms-chart.fullname" . }}-pms
         image: {{ include "pms-chart.image" . }}

--- a/charts/plex-media-server/values.yaml
+++ b/charts/plex-media-server/values.yaml
@@ -115,6 +115,22 @@ initContainer:
   #
   #   echo "Done."
 
+extraInitContainers: {}
+# extraContainers:
+#  - name: <container name>
+#    args:
+#      - ...
+#    image: <docker images>
+#    imagePullPolicy: IfNotPresent
+#    resources:
+#      limits:
+#        memory: 128Mi
+#      requests:
+#        cpu: 100m
+#        memory: 128Mi
+#    volumeMounts:
+#      - ...
+
 # -- Specify your own runtime class name eg use gpu
 runtimeClassName: ""
 


### PR DESCRIPTION
The current chart asserts that only a single init container is needed for rclone. This can be adapted for most purposes so long as the specified image contains an entrypoint at /init/init.sh and is meant to be run as an initContainer and not a sidecar container (https://kubernetes.io/docs/concepts/workloads/pods/init-containers/#api-for-sidecar-containers).

There are useful tools that operate on plex's metadata files, bundles, or database that would be best run as sidecar containers (see above), which are functionally init containers with restart policies.

This pull request adds support for additional init containers through an "extraInitContainers" argument that is semantically identical to the existing extraContainers argument.

