### PR TITLE
[helm chart] Allow the pms container to run as privileged

### DIFF
--- a/charts/plex-media-server/templates/statefulset.yaml
+++ b/charts/plex-media-server/templates/statefulset.yaml
@@ -126,11 +126,13 @@ spec:
         readinessProbe:
           {{- toYaml . | nindent 10 }}
         {{- end }}
+        {{- if .Values.pms.privileged }}
         securityContext:
           privileged: true
           capabilities:
             add:
               - SYS_ADMIN
+        {{- end }}
         {{- with .Values.pms.resources }}
         resources:
           limits:

--- a/charts/plex-media-server/templates/statefulset.yaml
+++ b/charts/plex-media-server/templates/statefulset.yaml
@@ -126,6 +126,11 @@ spec:
         readinessProbe:
           {{- toYaml . | nindent 10 }}
         {{- end }}
+        securityContext:
+          privileged: true
+          capabilities:
+            add:
+              - SYS_ADMIN
         {{- with .Values.pms.resources }}
         resources:
           limits:

--- a/charts/plex-media-server/values.yaml
+++ b/charts/plex-media-server/values.yaml
@@ -47,6 +47,10 @@ pms:
     nvidia:
       enabled: false
 
+  # Enabling this will run the pms container as a privileged process
+  # This may be necessary to use intel iGPU for hardware rendering
+  # privileged: true
+
   resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little


### PR DESCRIPTION
Hello

I've try to make hardware transcoding with an intel igpu work as a non privileged container with no success.
If it is possible I'd like some pointers on how to do that
If not this pr adds the ability to run the pms container as privileged

Thanks for providing an official chart 🙏 