### PR TITLE
Update alpine and rclone image tags

### DIFF
--- a/.github/linters/ct.yaml
+++ b/.github/linters/ct.yaml
@@ -1,3 +1,4 @@
+target-branch: master
 chart-dirs:
 - charts
 validate-maintainers: false

--- a/charts/plex-media-server/values.yaml
+++ b/charts/plex-media-server/values.yaml
@@ -4,7 +4,7 @@ image:
   registry: index.docker.io
   repository: plexinc/pms-docker
   # -- If unset use "latest"
-  tag: "latest"
+  tag: "1.41.5.9522-a96edc606"
   sha: ""
   pullPolicy: IfNotPresent
 
@@ -156,7 +156,6 @@ rclone:
   # be useful if other files are needed, such as a private key for sftp mode.
   configSecret: ""
 
-
   # -- The remote drive that should be mounted using rclone
   # this must be in the form of `name:[/optional/path]`
   # this remote will be mounted at `/data/name` in the PMS container
@@ -220,7 +219,6 @@ service:
   # -- Optional extra annotations to add to the service resource
   annotations: {}
 
-
 nodeSelector: {}
 
 tolerations: []
@@ -245,7 +243,6 @@ extraEnv: {}
 # a list of CIDRs that can use the server without authentication
   # this is only used for the first startup of PMS
 #   ALLOWED_NETWORKS: "0.0.0.0/0"
-
 
 # -- Optionally specify additional volume mounts for the PMS and init containers.
 extraVolumeMounts: []

--- a/charts/plex-media-server/values.yaml
+++ b/charts/plex-media-server/values.yaml
@@ -87,7 +87,7 @@ initContainer:
     registry: index.docker.io
     repository: alpine
     # -- If unset use latest
-    tag: 3
+    tag: 3.21
     sha: ""
     pullPolicy: IfNotPresent
 

--- a/charts/plex-media-server/values.yaml
+++ b/charts/plex-media-server/values.yaml
@@ -87,7 +87,7 @@ initContainer:
     registry: index.docker.io
     repository: alpine
     # -- If unset use latest
-    tag: 3.18.0
+    tag: 3
     sha: ""
     pullPolicy: IfNotPresent
 
@@ -145,7 +145,7 @@ rclone:
     registry: index.docker.io
     repository: rclone/rclone
     # -- If unset use latest
-    tag: 1.62.2
+    tag: 1.69.0
     sha: ""
     pullPolicy: IfNotPresent
 


### PR DESCRIPTION
Update rclone container image version from 1.62 to 1.69 and alpine init container from 3.18 to 3 which is using the latest minor version of alpine. 

Alternatively we can use 3.21 but I would appreciate if you add dependabot or renovate.