### PR TITLE
Update statefulset.yaml

### DIFF
--- a/charts/plex-media-server/templates/statefulset.yaml
+++ b/charts/plex-media-server/templates/statefulset.yaml
@@ -21,6 +21,10 @@ spec:
       annotations:
         {{- toYaml .Values.statefulSet.podAnnotations | nindent 8 }}
     spec:
+      dnsConfig:
+        options:
+          - name: ndots
+            value: "1"
       {{- if .Values.runtimeClassName }}
       runtimeClassName: {{ .Values.runtimeClassName | quote }}
       {{- end }}


### PR DESCRIPTION
Also see: https://pracucci.com/kubernetes-dns-resolution-ndots-options-and-why-it-may-affect-application-performances.html

And: https://forums.plex.tv/t/claiming-a-plex-media-server-docker-kubernetes/914912/24

Simply put: Kubernetes is trying to internally resolve "plex.tv" because it thinks this is a internal service name (only 1 dot).

We can either make plex media server try and resolve the actual FQDN for `plex.tv.` (ending with a dot)

Or add this dnsconfig to the statefulset.