### PR TITLE
Add more flexible TLS configuration

### DIFF
--- a/charts/plex-media-server/Chart.yaml
+++ b/charts/plex-media-server/Chart.yaml
@@ -22,7 +22,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.9.1
+version: 1.0.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/plex-media-server/templates/ingress.yaml
+++ b/charts/plex-media-server/templates/ingress.yaml
@@ -25,8 +25,16 @@ spec:
             name: {{ include "pms-chart.fullname" . }}
             port:
               number: 32400
-  tls:
-  - hosts:
-    - {{ trimPrefix "https://" .Values.ingress.url }}
-    secretName: {{ .Values.ingress.certificateSecret | default (printf "%s-ingress-lets-encrypt" (include "pms-chart.fullname" .)) }}
+  {{- if .Values.ingress.tls }}
+    tls:
+      {{- range .Values.ingress.tls }}
+      - hosts:
+        {{- range .hosts }}
+          - {{ tpl . $ | quote }}
+        {{- end }}
+        {{- with .secretName }}
+        secretName: {{ tpl . $ }}
+        {{- end }}
+      {{- end }}
+  {{- end }}
 {{- end -}}

--- a/charts/plex-media-server/values.yaml
+++ b/charts/plex-media-server/values.yaml
@@ -24,11 +24,10 @@ ingress:
 
   # -- Optional TLS configuration to provide valid https connections
   # using an existing SSL certificate
-  # tls:
+  tls: []
   #   - hosts:
   #       - plex.example.com
-  #     secretName: ""
-  tls: []
+  #     secretName: cert-example-com
 
   # -- Custom annotations to put on the ingress resource
   annotations: {}

--- a/charts/plex-media-server/values.yaml
+++ b/charts/plex-media-server/values.yaml
@@ -22,9 +22,13 @@ ingress:
   # -- The url to use for the ingress reverse proxy to point at this pms instance
   url: ""
 
-  # -- Optional secret name to provide valid https connections
+  # -- Optional TLS configuration to provide valid https connections
   # using an existing SSL certificate
-  certificateSecret: ""
+  # tls:
+  #   - hosts:
+  #       - plex.example.com
+  #     secretName: ""
+  tls: []
 
   # -- Custom annotations to put on the ingress resource
   annotations: {}


### PR DESCRIPTION
This is a breaking change to the configuration, but it allows for a more flexible TLS configuration.

The current configuration doesn't allow you to configure TLS and also leave the secretName option un-configured which allows you to use the ingress' default TLS certificate.