### PR TITLE
feat: add dnsConfig to StatefulSet 

### DIFF
--- a/charts/plex-media-server/Chart.yaml
+++ b/charts/plex-media-server/Chart.yaml
@@ -22,7 +22,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.9.1
+version: 0.10.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/plex-media-server/README.md
+++ b/charts/plex-media-server/README.md
@@ -1,6 +1,6 @@
 # plex-media-server
 
-![Version: 0.9.1](https://img.shields.io/badge/Version-0.9.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.41.5](https://img.shields.io/badge/AppVersion-1.41.5-informational?style=flat-square)
+![Version: 0.10.0](https://img.shields.io/badge/Version-0.10.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.41.6](https://img.shields.io/badge/AppVersion-1.41.6-informational?style=flat-square)
 
 **Homepage:** <https://www.plex.tv>
 
@@ -118,9 +118,9 @@ Before contributing, please read the [Code of Conduct](../../CODE_OF_CONDUCT.md)
 | ingress.enabled | bool | `false` | Specify if an ingress resource for the pms server should be created or not |
 | ingress.ingressClassName | string | `"ingress-nginx"` | The ingress class that should be used |
 | ingress.url | string | `""` | The url to use for the ingress reverse proxy to point at this pms instance |
-| initContainer | object | `{"image":{"pullPolicy":"IfNotPresent","registry":"index.docker.io","repository":"alpine","sha":"","tag":3.21},"script":""}` | A basic image that will convert the configmap to a file in the rclone config volume this is ignored if rclone is not enabled |
+| initContainer | object | `{"image":{"pullPolicy":"IfNotPresent","registry":"index.docker.io","repository":"alpine","sha":"","tag":"3.21"},"script":""}` | A basic image that will convert the configmap to a file in the rclone config volume this is ignored if rclone is not enabled |
 | initContainer.image.registry | string | `"index.docker.io"` | The public dockerhub registry |
-| initContainer.image.tag | float | `3.21` | If unset use latest |
+| initContainer.image.tag | string | `"3.21"` | If unset use latest |
 | initContainer.script | string | `""` | A custom script that will be run in an init container to do any setup before the PMS service starts up This will be run every time the pod starts, make sure that some mechanism is included to prevent this from running more than once if it should only be run on the first startup. |
 | nameOverride | string | `""` |  |
 | nodeSelector | object | `{}` |  |
@@ -134,13 +134,13 @@ Before contributing, please read the [Code of Conduct](../../CODE_OF_CONDUCT.md)
 | pms.shareProcessNamespace | bool | `false` | Enable process namespace sharing within the pod. |
 | pms.storageClassName | string | `nil` | The storage class to use when provisioning the pms config volume this needs to be created manually, null will use the default |
 | priorityClassName | string | `""` |  |
-| rclone | object | `{"additionalArgs":[],"configSecret":"","enabled":false,"image":{"pullPolicy":"IfNotPresent","registry":"index.docker.io","repository":"rclone/rclone","sha":"","tag":"1.69.1"},"readOnly":true,"remotes":[],"resources":{}}` | The settings specific to rclone |
+| rclone | object | `{"additionalArgs":[],"configSecret":"","enabled":false,"image":{"pullPolicy":"IfNotPresent","registry":"index.docker.io","repository":"rclone/rclone","sha":"","tag":"1.69.2"},"readOnly":true,"remotes":[],"resources":{}}` | The settings specific to rclone |
 | rclone.additionalArgs | list | `[]` | Additional arguments to give to rclone when mounting the volume |
 | rclone.configSecret | string | `""` | The name of the secret that contains the rclone configuration file. The rclone config key must be called `rclone.conf` in the secret  All keys in configSecret will be available in /etc/rclone/. This might be useful if other files are needed, such as a private key for sftp mode. |
 | rclone.enabled | bool | `false` | If the rclone sidecar should be created |
-| rclone.image | object | `{"pullPolicy":"IfNotPresent","registry":"index.docker.io","repository":"rclone/rclone","sha":"","tag":"1.69.1"}` | The rclone image that should be used |
+| rclone.image | object | `{"pullPolicy":"IfNotPresent","registry":"index.docker.io","repository":"rclone/rclone","sha":"","tag":"1.69.2"}` | The rclone image that should be used |
 | rclone.image.registry | string | `"index.docker.io"` | The public dockerhub registry |
-| rclone.image.tag | string | `"1.69.1"` | If unset use latest |
+| rclone.image.tag | string | `"1.69.2"` | If unset use latest |
 | rclone.readOnly | bool | `true` | If the remote volumes should be mounted as read only |
 | rclone.remotes | list | `[]` | The remote drive that should be mounted using rclone this must be in the form of `name:[/optional/path]` this remote will be mounted at `/data/name` in the PMS container |
 | runtimeClassName | string | `""` | Specify your own runtime class name eg use gpu |

--- a/charts/plex-media-server/README.md
+++ b/charts/plex-media-server/README.md
@@ -101,6 +101,7 @@ Before contributing, please read the [Code of Conduct](../../CODE_OF_CONDUCT.md)
 |-----|------|---------|-------------|
 | affinity | object | `{}` |  |
 | commonLabels | object | `{}` | Common Labels for all resources created by this chart. |
+| dnsConfig | object | `{}` | Optional DNS configuration for the Pod |
 | extraContainers | list | `[]` |  |
 | extraEnv | object | `{}` |  |
 | extraInitContainers | object | `{}` |  |
@@ -117,9 +118,9 @@ Before contributing, please read the [Code of Conduct](../../CODE_OF_CONDUCT.md)
 | ingress.enabled | bool | `false` | Specify if an ingress resource for the pms server should be created or not |
 | ingress.ingressClassName | string | `"ingress-nginx"` | The ingress class that should be used |
 | ingress.url | string | `""` | The url to use for the ingress reverse proxy to point at this pms instance |
-| initContainer | object | `{"image":{"pullPolicy":"IfNotPresent","registry":"index.docker.io","repository":"alpine","sha":"","tag":"3.18.0"},"script":""}` | A basic image that will convert the configmap to a file in the rclone config volume this is ignored if rclone is not enabled |
+| initContainer | object | `{"image":{"pullPolicy":"IfNotPresent","registry":"index.docker.io","repository":"alpine","sha":"","tag":3.21},"script":""}` | A basic image that will convert the configmap to a file in the rclone config volume this is ignored if rclone is not enabled |
 | initContainer.image.registry | string | `"index.docker.io"` | The public dockerhub registry |
-| initContainer.image.tag | string | `"3.18.0"` | If unset use latest |
+| initContainer.image.tag | float | `3.21` | If unset use latest |
 | initContainer.script | string | `""` | A custom script that will be run in an init container to do any setup before the PMS service starts up This will be run every time the pod starts, make sure that some mechanism is included to prevent this from running more than once if it should only be run on the first startup. |
 | nameOverride | string | `""` |  |
 | nodeSelector | object | `{}` |  |
@@ -133,13 +134,13 @@ Before contributing, please read the [Code of Conduct](../../CODE_OF_CONDUCT.md)
 | pms.shareProcessNamespace | bool | `false` | Enable process namespace sharing within the pod. |
 | pms.storageClassName | string | `nil` | The storage class to use when provisioning the pms config volume this needs to be created manually, null will use the default |
 | priorityClassName | string | `""` |  |
-| rclone | object | `{"additionalArgs":[],"configSecret":"","enabled":false,"image":{"pullPolicy":"IfNotPresent","registry":"index.docker.io","repository":"rclone/rclone","sha":"","tag":"1.62.2"},"readOnly":true,"remotes":[],"resources":{}}` | The settings specific to rclone |
+| rclone | object | `{"additionalArgs":[],"configSecret":"","enabled":false,"image":{"pullPolicy":"IfNotPresent","registry":"index.docker.io","repository":"rclone/rclone","sha":"","tag":"1.69.1"},"readOnly":true,"remotes":[],"resources":{}}` | The settings specific to rclone |
 | rclone.additionalArgs | list | `[]` | Additional arguments to give to rclone when mounting the volume |
 | rclone.configSecret | string | `""` | The name of the secret that contains the rclone configuration file. The rclone config key must be called `rclone.conf` in the secret  All keys in configSecret will be available in /etc/rclone/. This might be useful if other files are needed, such as a private key for sftp mode. |
 | rclone.enabled | bool | `false` | If the rclone sidecar should be created |
-| rclone.image | object | `{"pullPolicy":"IfNotPresent","registry":"index.docker.io","repository":"rclone/rclone","sha":"","tag":"1.62.2"}` | The rclone image that should be used |
+| rclone.image | object | `{"pullPolicy":"IfNotPresent","registry":"index.docker.io","repository":"rclone/rclone","sha":"","tag":"1.69.1"}` | The rclone image that should be used |
 | rclone.image.registry | string | `"index.docker.io"` | The public dockerhub registry |
-| rclone.image.tag | string | `"1.62.2"` | If unset use latest |
+| rclone.image.tag | string | `"1.69.1"` | If unset use latest |
 | rclone.readOnly | bool | `true` | If the remote volumes should be mounted as read only |
 | rclone.remotes | list | `[]` | The remote drive that should be mounted using rclone this must be in the form of `name:[/optional/path]` this remote will be mounted at `/data/name` in the PMS container |
 | runtimeClassName | string | `""` | Specify your own runtime class name eg use gpu |

--- a/charts/plex-media-server/README.md
+++ b/charts/plex-media-server/README.md
@@ -109,9 +109,9 @@ Before contributing, please read the [Code of Conduct](../../CODE_OF_CONDUCT.md)
 | extraVolumes | list | `[]` | Optionally specify additional volumes for the pod. |
 | fullnameOverride | string | `""` |  |
 | global.imageRegistry | string | `""` | Allow parent charts to override registry hostname |
-| image | object | `{"pullPolicy":"IfNotPresent","registry":"index.docker.io","repository":"plexinc/pms-docker","sha":"","tag":"1.41.5.9522-a96edc606"}` | The docker image information for the pms application |
+| image | object | `{"pullPolicy":"IfNotPresent","registry":"index.docker.io","repository":"plexinc/pms-docker","sha":"","tag":"1.41.6.9685-d301f511a"}` | The docker image information for the pms application |
 | image.registry | string | `"index.docker.io"` | The public dockerhub registry |
-| image.tag | string | `"1.41.5.9522-a96edc606"` | If unset use "latest" |
+| image.tag | string | `"1.41.6.9685-d301f511a"` | If unset use "latest" |
 | imagePullSecrets | list | `[]` |  |
 | ingress.annotations | object | `{}` | Custom annotations to put on the ingress resource |
 | ingress.certificateSecret | string | `""` | Optional secret name to provide valid https connections using an existing SSL certificate |

--- a/charts/plex-media-server/templates/service.yaml
+++ b/charts/plex-media-server/templates/service.yaml
@@ -17,12 +17,12 @@ spec:
   externalTrafficPolicy: {{ .Values.service.externalTrafficPolicy }}
   {{- end }}
   ports:
-    - port: {{ .Values.service.port }}
-      targetPort: 32400
-      {{- if eq .Values.service.type "NodePort" }}
-      nodePort: {{ default "32400" .Values.service.nodePort }}
-      {{- end }}
-      protocol: TCP
-      name: pms
+  - port: {{ .Values.service.port }}
+    targetPort: 32400
+    {{- if eq .Values.service.type "NodePort" }}
+    nodePort: {{ default "32400" .Values.service.nodePort }}
+    {{- end }}
+    protocol: TCP
+    name: pms
   selector:
     {{- include "pms-chart.selectorLabels" . | nindent 4 }}

--- a/charts/plex-media-server/templates/statefulset.yaml
+++ b/charts/plex-media-server/templates/statefulset.yaml
@@ -21,6 +21,10 @@ spec:
       annotations:
         {{- toYaml .Values.statefulSet.podAnnotations | nindent 8 }}
     spec:
+      {{- if .Values.dnsConfig }}
+      dnsConfig:
+        {{- toYaml .Values.dnsConfig | nindent 8 }}
+      {{- end }}
       {{- if .Values.runtimeClassName }}
       runtimeClassName: {{ .Values.runtimeClassName | quote }}
       {{- end }}

--- a/charts/plex-media-server/values.yaml
+++ b/charts/plex-media-server/values.yaml
@@ -96,7 +96,7 @@ initContainer:
     registry: index.docker.io
     repository: alpine
     # -- If unset use latest
-    tag: 3.21
+    tag: '3.21'
     sha: ""
     pullPolicy: IfNotPresent
 

--- a/charts/plex-media-server/values.yaml
+++ b/charts/plex-media-server/values.yaml
@@ -213,6 +213,13 @@ service:
   type: ClusterIP
   port: 32400
 
+  # -- Deprecated: Pre-defined IP address of the PMS service.
+  # Used by cloud providers to connect the resulting load balancer service to a
+  # pre-existing static IP.
+  # Users are encouraged to use implementation-specific annotations when available instead.
+  # Ref: https://kubernetes.io/docs/concepts/services-networking/service/#loadbalancer
+  # loadBalancerIP: ""
+
   # Port to use when type of service is "NodePort" (32400 by default)
   # nodePort: 32400
 

--- a/charts/plex-media-server/values.yaml
+++ b/charts/plex-media-server/values.yaml
@@ -12,6 +12,9 @@ global:
   # -- Allow parent charts to override registry hostname
   imageRegistry: ""
 
+# -- Optional DNS configuration for the Pod
+dnsConfig: {}
+
 ingress:
   # -- Specify if an ingress resource for the pms server should be created or not
   enabled: false

--- a/charts/plex-media-server/values.yaml
+++ b/charts/plex-media-server/values.yaml
@@ -4,7 +4,7 @@ image:
   registry: index.docker.io
   repository: plexinc/pms-docker
   # -- If unset use "latest"
-  tag: "1.41.5.9522-a96edc606"
+  tag: "1.41.6.9685-d301f511a"
   sha: ""
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
Consolidating some suggestions from pending PRs.

Closes 

- add `spec.template.spec.dnsConfig` to the main STS (#138)
- update values file for `service.loadBalancerIP` (#137)
- bump pms to `1.41.6.9685-d301f511a` (#130)
- update service.ports indent to match the rest of the manifests
- update README

Bumps chart to v0.10