### PR TITLE
Support loading PLEX_CLAIM from a k8s Secret

### DIFF
--- a/charts/plex-media-server/templates/statefulset.yaml
+++ b/charts/plex-media-server/templates/statefulset.yaml
@@ -119,6 +119,13 @@ spec:
         - name: {{ $key }}
           value: {{ $value | quote }}
         {{- end }}
+        {{- if and .Values.pms.claimSecretName .Values.pms.claimSecretValue }}
+        - name: PLEX_CLAIM
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.pms.claimSecretName }}
+              key: {{ .Values.pms.claimSecretValue }}
+        {{- end }}
         {{- if .Values.pms.gpu.nvidia.enabled }}
         - name: NVIDIA_VISIBLE_DEVICES
           value: all

--- a/charts/plex-media-server/values.yaml
+++ b/charts/plex-media-server/values.yaml
@@ -44,6 +44,12 @@ pms:
   # NOTE: When set, 'configStorage' and 'storageClassName' are ignored.
   configExistingClaim: ""
 
+  # Providing both values will add in the PLEX_CLAIM environment variable
+  # with the correct secretKeyRef configuration
+  # Clashes with providing PLEX_CLAIM via `extraEnv` so only provide one or the other!
+  claimSecretName: ""
+  claimSecretValue: ""
+
   # Enabling this will add nvidia.com/gpu: 1 to limits, and will set
   # environment for the nvidia operator
   gpu:


### PR DESCRIPTION
Having a public gitops setup means requiring the expose the PLEX_CLAIM for the short period of time before CICD deploys the updates to the Pod and the claim token is consumed.

It would be great if we can instead load this in via a `secretKeyRef` stanza!