### PR TITLE
Fixing indenting of tls config in ingress template

### DIFF
--- a/charts/plex-media-server/Chart.yaml
+++ b/charts/plex-media-server/Chart.yaml
@@ -22,7 +22,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.0
+version: 1.0.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/plex-media-server/templates/ingress.yaml
+++ b/charts/plex-media-server/templates/ingress.yaml
@@ -26,15 +26,15 @@ spec:
             port:
               number: 32400
   {{- if .Values.ingress.tls }}
-    tls:
-      {{- range .Values.ingress.tls }}
-      - hosts:
-        {{- range .hosts }}
-          - {{ tpl . $ | quote }}
-        {{- end }}
-        {{- with .secretName }}
-        secretName: {{ tpl . $ }}
-        {{- end }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+      {{- range .hosts }}
+        - {{ tpl . $ | quote }}
       {{- end }}
+      {{- with .secretName }}
+      secretName: {{ tpl . $ }}
+      {{- end }}
+    {{- end }}
   {{- end }}
 {{- end -}}


### PR DESCRIPTION
With the v1 change of the helm chart, the indenting of the tls block shifted right by 2 spaces, effectively removing the tls config altogether. This fixes that by shifting the tls block to the left again by 2 spaces.