### PR TITLE
fix: set correct port for plex apps

### DIFF
--- a/charts/plex-media-server/templates/statefulset.yaml
+++ b/charts/plex-media-server/templates/statefulset.yaml
@@ -116,7 +116,7 @@ spec:
         env:
         {{- if .Values.ingress.enabled }}
         - name: ADVERTISE_IP
-          value: {{ .Values.ingress.url }}:443
+          value: {{ .Values.ingress.url }}:80
         {{- end }}
         {{- range $key, $value := .Values.extraEnv }}
         - name: {{ $key }}


### PR DESCRIPTION
I was not able to reach my server with the Apple TV / IOS app. After I changed the port from 443 to 80, I could reach the server.