### PR TITLE
feat: bump pms to 1.41.7.9823-59f304c16

### DIFF
--- a/charts/plex-media-server/Chart.yaml
+++ b/charts/plex-media-server/Chart.yaml
@@ -28,7 +28,7 @@ version: 1.0.2
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.41.6"
+appVersion: "1.41.7"
 
 sources:
 - https://github.com/plexinc/pms-docker

--- a/charts/plex-media-server/README.md
+++ b/charts/plex-media-server/README.md
@@ -1,6 +1,6 @@
 # plex-media-server
 
-![Version: 1.0.2](https://img.shields.io/badge/Version-1.0.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.41.6](https://img.shields.io/badge/AppVersion-1.41.6-informational?style=flat-square)
+![Version: 1.0.2](https://img.shields.io/badge/Version-1.0.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.41.7](https://img.shields.io/badge/AppVersion-1.41.7-informational?style=flat-square)
 
 **Homepage:** <https://www.plex.tv>
 
@@ -109,9 +109,9 @@ Before contributing, please read the [Code of Conduct](../../CODE_OF_CONDUCT.md)
 | extraVolumes | list | `[]` | Optionally specify additional volumes for the pod. |
 | fullnameOverride | string | `""` |  |
 | global.imageRegistry | string | `""` | Allow parent charts to override registry hostname |
-| image | object | `{"pullPolicy":"IfNotPresent","registry":"index.docker.io","repository":"plexinc/pms-docker","sha":"","tag":"1.41.6.9685-d301f511a"}` | The docker image information for the pms application |
+| image | object | `{"pullPolicy":"IfNotPresent","registry":"index.docker.io","repository":"plexinc/pms-docker","sha":"","tag":"1.41.7.9823-59f304c16"}` | The docker image information for the pms application |
 | image.registry | string | `"index.docker.io"` | The public dockerhub registry |
-| image.tag | string | `"1.41.6.9685-d301f511a"` | If unset use "latest" |
+| image.tag | string | `"1.41.7.9823-59f304c16"` | If unset use "latest" |
 | imagePullSecrets | list | `[]` |  |
 | ingress.annotations | object | `{}` | Custom annotations to put on the ingress resource |
 | ingress.enabled | bool | `false` | Specify if an ingress resource for the pms server should be created or not |

--- a/charts/plex-media-server/values.yaml
+++ b/charts/plex-media-server/values.yaml
@@ -4,7 +4,7 @@ image:
   registry: index.docker.io
   repository: plexinc/pms-docker
   # -- If unset use "latest"
-  tag: "1.41.6.9685-d301f511a"
+  tag: "1.41.7.9823-59f304c16"
   sha: ""
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
bump pms to `1.41.7.9823-59f304c16`

I'm not sure if it has been discussed somewhere, but is there a plan to keep the Helm chart image tag up to date with the application? I recently added this chart to my flux workflow. If not, I can add renovate config on my repo to keep me up to date.