### PR TITLE
fix: if statement breaks "env"

### DIFF
--- a/charts/plex-media-server/templates/statefulset.yaml
+++ b/charts/plex-media-server/templates/statefulset.yaml
@@ -113,8 +113,8 @@ spec:
         ports:
         - containerPort: 32400
           name: pms
-        {{- if or .Values.ingress.enabled .Values.extraEnv.ADVERTISE_IP }}
         env:
+        {{- if or .Values.ingress.enabled .Values.extraEnv.ADVERTISE_IP }}
         - name: ADVERTISE_IP
           value: {{ .Values.extraEnv.ADVERTISE_IP | default (printf "%s:443" .Values.ingress.url) }}
         {{- end }}


### PR DESCRIPTION
The statement introduced breaks the helmchart. If ingress or ADVERTISE_IP is not defined the chart fails as "env:" is missing.