### PR TITLE
fix(docker): remove default ubuntu user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,8 @@ ENV TERM="xterm" LANG="C.UTF-8" LC_ALL="C.UTF-8"
 ENTRYPOINT ["/init"]
 
 # Add user
-RUN useradd -U -d /config -s /bin/false plex && \
+RUN userdel -r ubuntu && \
+    useradd -U -d /config -s /bin/false plex && \
     usermod -G users plex && \
     \
 # Setup directories


### PR DESCRIPTION
A default `ubuntu` user was added on ubuntu images 22.10 and up. This breaks permissions on some existing installations due to the default `plex` user now having a different UID (1001).

This removes the default `ubuntu` user and restores the previous UID for the `plex` user.

Regression introduced in #148 

References:
- https://bugs.launchpad.net/cloud-images/+bug/2005129
- https://forums.plex.tv/t/plex-docker-image-should-not-change-permissions-on-mounted-volumes-if-pid-and-gid-is-defined/928780
- https://forums.plex.tv/t/custom-domain-ssl-does-not-work-after-update-to-server-version-1-42-1-10060-4e8b05daf/928405