### PR TITLE
feat: Add missing namespace field to Helm templates

### DIFF
--- a/charts/plex-media-server/templates/configmap-init-script.yaml
+++ b/charts/plex-media-server/templates/configmap-init-script.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name:  {{ include "pms-chart.fullname" . }}-init-script
+  namespace: {{ .Release.Namespace }}
   labels:
 {{- include "pms-chart.labels" . | nindent 4 }}
 data:

--- a/charts/plex-media-server/templates/httproute.yaml
+++ b/charts/plex-media-server/templates/httproute.yaml
@@ -3,6 +3,7 @@ apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
   name: {{ include "pms-chart.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels: {{ include "pms-chart.labels" . | nindent 4 }}
   {{- with .Values.httpRoute.annotations }}
   annotations: {{ toYaml . | nindent 4 }}

--- a/charts/plex-media-server/templates/ingress.yaml
+++ b/charts/plex-media-server/templates/ingress.yaml
@@ -3,6 +3,7 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ include "pms-chart.fullname" . }}-ingress
+  namespace: {{ .Release.Namespace }}
   labels:
     name: {{ include "pms-chart.fullname" . }}-ingress
 {{ include "pms-chart.labels" . | indent 4 }}

--- a/charts/plex-media-server/templates/service.yaml
+++ b/charts/plex-media-server/templates/service.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "pms-chart.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "pms-chart.labels" . | nindent 4 }}
   {{- with .Values.service.annotations }}

--- a/charts/plex-media-server/templates/serviceaccount.yaml
+++ b/charts/plex-media-server/templates/serviceaccount.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "pms-chart.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "pms-chart.labels" . | nindent 4 }}
   {{- with .Values.serviceAccount.annotations }}

--- a/charts/plex-media-server/templates/statefulset.yaml
+++ b/charts/plex-media-server/templates/statefulset.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: {{ include "pms-chart.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     name: {{ include "pms-chart.fullname" . }}
 {{ include "pms-chart.labels" . | indent 4 }}


### PR DESCRIPTION
Should fix this:

<img width="1769" height="439" alt="Screenshot 2026-03-06 at 2 00 45 PM" src="https://github.com/user-attachments/assets/6b8b3d50-e54a-42ce-9363-c7916fc93edc" />

When deploying to K8s with Argo CD like this:
```yaml
namespace: plex-media-server-system

resources:
  - resources/namespace.yml
  - resources/persistentVolume.yml
  - resources/persistentVolumeClaim.yml

commonLabels:
  app.kubernetes.io/name: plex-media-server

helmCharts:
  - includeCRDs: true
    name: plex-media-server
    namespace: plex-media-server-system
    releaseName: plex-media-server
    repo: https://raw.githubusercontent.com/plexinc/pms-docker/gh-pages
    valuesFile: values.yml
    version: 1.4.0

# The Helm Chart doesn't support disabling the dynamic config PersistentVolume.
# I do want one, but I want to statically reference a Mountpoint instead.
patches:
  - patch: |-
      apiVersion: apps/v1
      kind: StatefulSet
      metadata:
        name: plex-media-server
      spec:
        template:
          spec:
            containers:
            - name: plex-media-server-pms
              volumeMounts:
              - name: pms-config
                mountPath: /config
        volumeClaimTemplates:
    target:
      kind: StatefulSet
      name: plex-media-server
```
