### PR TITLE
feat: add support for Service.spec.trafficDistribution

### DIFF
--- a/charts/plex-media-server/Chart.yaml
+++ b/charts/plex-media-server/Chart.yaml
@@ -22,7 +22,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.4.0
+version: 1.5.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/plex-media-server/Chart.yaml
+++ b/charts/plex-media-server/Chart.yaml
@@ -28,7 +28,7 @@ version: 1.4.0
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.42.2"
+appVersion: "1.43.0"
 
 sources:
 - https://github.com/plexinc/pms-docker

--- a/charts/plex-media-server/README.md
+++ b/charts/plex-media-server/README.md
@@ -115,7 +115,7 @@ Before contributing, please read the [Code of Conduct](../../CODE_OF_CONDUCT.md)
 | httpRoute.enabled | bool | `false` | Specify if an HTTPRoute resource for the pms server should be created or not |
 | httpRoute.hostnames | list | `[]` | Hostnames to match for the HTTPRoute |
 | httpRoute.parentRefs | list | `[]` | Gateway API parent references (required when enabled) |
-| image | object | `{"pullPolicy":"IfNotPresent","registry":"index.docker.io","repository":"plexinc/pms-docker","sha":"","tag":"1.42.2.10156-f737b826c"}` | The docker image information for the pms application |
+| image | object | `{"pullPolicy":"IfNotPresent","registry":"index.docker.io","repository":"plexinc/pms-docker","sha":"","tag":"1.43.0.10492-121068a07"}` | The docker image information for the pms application |
 | image.registry | string | `"index.docker.io"` | The public dockerhub registry |
 | imagePullSecrets | list | `[]` |  |
 | ingress.annotations | object | `{}` | Custom annotations to put on the ingress resource |

--- a/charts/plex-media-server/README.md
+++ b/charts/plex-media-server/README.md
@@ -1,6 +1,6 @@
 # plex-media-server
 
-![Version: 1.4.0](https://img.shields.io/badge/Version-1.4.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.42.2](https://img.shields.io/badge/AppVersion-1.42.2-informational?style=flat-square)
+![Version: 1.5.0](https://img.shields.io/badge/Version-1.5.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.43.0](https://img.shields.io/badge/AppVersion-1.43.0-informational?style=flat-square)
 
 **Homepage:** <https://www.plex.tv>
 

--- a/charts/plex-media-server/templates/service.yaml
+++ b/charts/plex-media-server/templates/service.yaml
@@ -11,6 +11,9 @@ metadata:
   {{- end }}
 spec:
   type: {{ .Values.service.type }}
+  {{- if .Values.service.trafficDistribution }}
+  trafficDistribution: {{ .Values.service.trafficDistribution }}
+  {{- end }}
   {{- if .Values.service.loadBalancerIP }}
   loadBalancerIP: {{ .Values.service.loadBalancerIP }}
   {{- end }}

--- a/charts/plex-media-server/values.yaml
+++ b/charts/plex-media-server/values.yaml
@@ -4,7 +4,7 @@ image:
   registry: index.docker.io
   repository: plexinc/pms-docker
   # renovate: datasource=custom.plex depName=plex versioning=loose
-  tag: "1.42.2.10156-f737b826c"
+  tag: "1.43.0.10492-121068a07"
   sha: ""
   pullPolicy: IfNotPresent
 

--- a/charts/plex-media-server/values.yaml
+++ b/charts/plex-media-server/values.yaml
@@ -259,6 +259,14 @@ service:
   type: ClusterIP
   port: 32400
 
+  # -- TrafficDistribution offers a way to express preferences for how traffic
+  # is distributed to Service endpoints. If the field is not set, the
+  # implementation will apply its default routing strategy. If set to
+  # "PreferSameNode" (k8s v1.35+) implementations should prioritize endpoints
+  # that are in the same zone. Clusters running k8s v1.34 or earlier should use
+  # "PreferClose" instead.
+  # trafficDistribution: PreferSameNode
+
   # -- Deprecated: Pre-defined IP address of the PMS service.
   # Used by cloud providers to connect the resulting load balancer service to a
   # pre-existing static IP.


### PR DESCRIPTION
Allow users to set trafficDistribution policy on the default Service.

Upgrade PMS tag to `1.43.0.10492`.

