### PR TITLE
fix: guard Plex finish kill when no PID is found

### DIFF
--- a/root/etc/services.d/plex/finish
+++ b/root/etc/services.d/plex/finish
@@ -3,10 +3,22 @@
 
 echo "Stopping Plex Media Server."
 
+kill_pids() {
+  local signal="$1"
+  local pids="$2"
+  local pid
+
+  while IFS= read -r pid; do
+    if [ "$pid" != "" ]; then
+      kill "$signal" "$pid"
+    fi
+  done <<< "$pids"
+}
+
 # Ask nicely
 pids="$(ps -ef | grep 'Plex Media Server' | grep -v grep | awk '{print $2}')"
 if [ "$pids" != "" ]; then
-  kill -15 $pids
+  kill_pids -15 "$pids"
 fi
 
 sleep 5
@@ -15,6 +27,6 @@ sleep 5
 pids="$(ps -ef | grep /usr/lib/plexmediaserver | grep -v grep | awk '{print $2}')"
 
 if [ "$pids" != "" ]; then
-  kill -9 $pids
+  kill_pids -9 "$pids"
   sleep 2
 fi

--- a/root/etc/services.d/plex/finish
+++ b/root/etc/services.d/plex/finish
@@ -5,7 +5,9 @@ echo "Stopping Plex Media Server."
 
 # Ask nicely
 pids="$(ps -ef | grep 'Plex Media Server' | grep -v grep | awk '{print $2}')"
-kill -15 $pids
+if [ "$pids" != "" ]; then
+  kill -15 $pids
+fi
 
 sleep 5
 


### PR DESCRIPTION
## Summary

Guard the initial `kill -15 $pids` call in `root/etc/services.d/plex/finish` so it only runs when a Plex Media Server PID was found.

## Why

If Plex has already exited by the time the finish script runs, `pids` is empty and the shell executes `kill -15` without a PID. That prints the `kill: usage...` message during container shutdown. The later SIGKILL block already guards against an empty PID list, so this makes the TERM path match the existing stuck-process path.

## Validation

- `bash -n root/etc/services.d/plex/finish`
- Reproduced in a downstream Unraid container using `plexinc/pms-docker:latest`, where the shutdown logs showed `kill: usage...`; applying the guard removed that message while Plex restarted healthy.
