### PR TITLE
feat: add PLEX_MANUAL_PORT env var for manual Remote Access port mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ plexinc/pms-docker
 
 Note: In this configuration, you must do some additional configuration:
 
-- If you wish your Plex Media Server to be accessible outside of your home network, you must manually setup port forwarding on your router to forward to the `ADVERTISE_IP` specified above.  By default you can forward port 32400, but if you choose to use a different external port, be sure you configure this in Plex Media Server's `Remote Access` settings.  With this type of docker networking, the Plex Media Server is essentially behind two routers and it cannot automatically setup port forwarding on its own.
+- If you wish your Plex Media Server to be accessible outside of your home network, you must manually setup port forwarding on your router to forward to the `ADVERTISE_IP` specified above.  By default you can forward port 32400, but if you choose to use a different external port, be sure you configure this in Plex Media Server's `Remote Access` settings or via the `PLEX_MANUAL_PORT` environment variable (see below).  With this type of docker networking, the Plex Media Server is essentially behind two routers and it cannot automatically setup port forwarding on its own, so setting `PLEX_MANUAL_PORT` is recommended to ensure remote clients connect directly instead of through the bandwidth-limited relay.
 - (Plex Pass only) After the server has been set up, you should configure the `LAN Networks` preference to contain the network of your LAN.  This instructs the Plex Media Server to treat these IP addresses as part of your LAN when applying bandwidth controls.  The syntax is the same as the `ALLOWED_NETWORKS` below.  For example `192.168.1.0/24,172.16.0.0/16` will allow access to the entire `192.168.1.x` range and the `172.16.x.x` range.
 
 ## Parameters
@@ -108,6 +108,7 @@ These parameters are usually not required but some special setups may benefit fr
 - **PLEX_UID** The user id of the `plex` user created inside the container.
 - **PLEX_GID** The group id of the `plex` group created inside the container
 - **CHANGE_CONFIG_DIR_OWNERSHIP** Change ownership of config directory to the plex user.  Defaults to `true`.  If you are certain permissions are already set such that the `plex` user within the container can read/write data in it's config directory, you can set this to `false` to speed up the first run of the container.
+- **PLEX_MANUAL_PORT** The public port that you have manually forwarded to the server (equivalent to enabling `Remote Access > Manually specify public port` in the server settings).  For example: `32400`.  Set this if your router/firewall does not support UPnP or NAT-PMP, or when using Bridge networking (where automatic port mapping cannot work); without it, the server never publishes a direct connection to plex.tv and remote clients silently fall back to the bandwidth-limited relay.
 - **ALLOWED_NETWORKS** IP/netmask entries which allow access to the server without requiring authorization.  We recommend you set this only if you do not sign in your server.  For example `192.168.1.0/24,172.16.0.0/16` will allow access to the entire `192.168.1.x` range and the `172.16.x.x` range.  Note: If you are using Bridge networking, then localhost will appear to plex as coming from the docker networking gateway which is often `172.16.0.1`.
 
 ## Users/Groups

--- a/root/etc/cont-init.d/40-plex-first-run
+++ b/root/etc/cont-init.d/40-plex-first-run
@@ -131,6 +131,16 @@ if [ ! -z "${ALLOWED_NETWORKS}" ]; then
   setPref "allowedNetworks" "${ALLOWED_NETWORKS}"
 fi
 
+# Configure Remote Access to use a manually mapped public port.  Without
+# this, servers behind routers/firewalls that do not offer UPnP/NAT-PMP
+# (or in Bridge networking, where the server is behind two layers of NAT)
+# never publish a direct WAN connection to plex.tv and remote clients
+# silently fall back to the bandwidth-limited relay.
+if [ ! -z "${PLEX_MANUAL_PORT}" ]; then
+  setPref "ManualPortMappingMode" "1"
+  setPref "ManualPortMappingPort" "${PLEX_MANUAL_PORT}"
+fi
+
 # Set transcoder temp if not yet set
 if [ -z "$(getPref "TranscoderTempDirectory")" ]; then
   setPref "TranscoderTempDirectory" "/transcode"


### PR DESCRIPTION
## Summary

- Adds a `PLEX_MANUAL_PORT` environment variable that sets `ManualPortMappingMode=1` and `ManualPortMappingPort=<value>` in `Preferences.xml`, equivalent to enabling **Remote Access > Manually specify public port** in the server settings.
- Implemented in `40-plex-first-run` directly alongside the existing `ADVERTISE_IP` / `ALLOWED_NETWORKS` handling, using the same `setPref` helper and the same first-run semantics.
- Documents the new variable in the README parameters list, and extends the Bridge-networking note (which already explains that automatic port mapping cannot work there) to point at it.

*(Note: this repository has issues disabled, so the problem report below is included here rather than as a linked issue.)*

## Problem

When Plex Media Server runs behind a router/firewall that does not offer UPnP/NAT-PMP (most business-grade firewalls, and effectively any Bridge-networking deployment, where the README notes the server is "essentially behind two routers"), automatic port mapping can never succeed. Unless the user manually enables **Settings > Remote Access > Manually specify public port** in the web UI, the server never publishes a direct WAN connection to plex.tv — even when a correct port-forward for 32400 is already in place and working.

The failure mode is silent and easy to misdiagnose: remote clients can complete their small candidate-test connections against the forwarded port, but the candidate list plex.tv serves them contains no direct WAN URI, so every remote stream falls back to the bandwidth-limited relay (~2 Mbps). Users see "speed issues" while their firewall shows the forwarded port open and passing traffic.

Confirmed on `plexinc/pms-docker:latest` (PMS 1.43.3): with a static DNAT for 32400 in place, `/myplex/account` showed `mappingState="mapped"` but `publicPort="0"`, and the plex.tv resources list had only LAN, custom, and relay candidates. Setting `ManualPortMappingMode=1` + `ManualPortMappingPort=32400` immediately produced the `https://<wan-ip-dashes>.<hash>.plex.direct:32400` candidate and remote clients switched from `relayed="1"` to `relayed="0"`.

Today the only fix is a manual, non-declarative GUI step that is lost if `Preferences.xml` is rebuilt. The container already maps `ADVERTISE_IP` and `ALLOWED_NETWORKS` onto `Preferences.xml`, and this image is *the* deployment shape where automatic mapping is most likely to be impossible, so this belongs alongside them.

## Test plan

- [x] Verified on a live deployment (PMS 1.43.3, bridge networking, firewall without UPnP, static 32400 DNAT): applying these two preferences flipped `/myplex/account` from `publicPort="0"` to `publicPort="32400"`, added the direct `plex.direct:32400` WAN candidate to the plex.tv resources list, and remote clients switched from `relayed="1"` to `relayed="0"`.
- [ ] Fresh-container first run with `-e PLEX_MANUAL_PORT=32400` writes both attributes to a clean `Preferences.xml`.
