### PR TITLE
fix: Make ingress service port configurable via Helm values, consistent wi…

### DIFF
--- a/charts/plex-media-server/templates/ingress.yaml
+++ b/charts/plex-media-server/templates/ingress.yaml
@@ -25,7 +25,7 @@ spec:
           service:
             name: {{ include "pms-chart.fullname" . }}
             port:
-              number: 32400
+              number: {{ .Values.service.port }}
   {{- if .Values.ingress.tls }}
   tls:
     {{- range .Values.ingress.tls }}


### PR DESCRIPTION
# Issue Summary:
When setting service.port to any other value than 32400, the ingress port number is not in-sync.
eg:
```yaml
service:
  type: LoadBalancer
  port: 12345
```
# Change
Change Ingress template to use the service port number from values rather than 32400 hardcoded

Other notes: 
- No changes necessary to httproute, it already references the correct port number
- Used ``.Values.service.port`` for consistency with httproute, rather than referencing by port name