### PR TITLE
feat(helm): add podSecurityContext

### DIFF
--- a/charts/plex-media-server/Chart.yaml
+++ b/charts/plex-media-server/Chart.yaml
@@ -22,7 +22,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.6.0
+version: 1.7.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/plex-media-server/README.md
+++ b/charts/plex-media-server/README.md
@@ -1,6 +1,6 @@
 # plex-media-server
 
-![Version: 1.6.0](https://img.shields.io/badge/Version-1.6.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.43.0](https://img.shields.io/badge/AppVersion-1.43.0-informational?style=flat-square)
+![Version: 1.7.0](https://img.shields.io/badge/Version-1.7.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.43.0](https://img.shields.io/badge/AppVersion-1.43.0-informational?style=flat-square)
 
 **Homepage:** <https://www.plex.tv>
 
@@ -138,9 +138,10 @@ Before contributing, please read the [Code of Conduct](../../CODE_OF_CONDUCT.md)
 | pms.gpu.nvidia.devices | string | `"all"` | Optional: NVIDIA GPU devices by index or UUID. Examples: "0,1", "GPU-uuid1,GPU-uuid2", or "all". See [NVIDIA docs](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/docker-specialized.html#gpu-enumeration) |
 | pms.gpu.nvidia.enabled | bool | `false` |  |
 | pms.livenessProbe | object | `{}` | Add kubernetes liveness probe to pms container. |
+| pms.podSecurityContext | object | `{}` | Security context applied to the PMS *pod*. Use this for pod-level fields such as `fsGroup`, `supplementalGroups` and `fsGroupChangePolicy`. |
 | pms.readinessProbe | object | `{}` | Add kubernetes readiness probe to pms container. |
 | pms.resources | object | `{}` |  |
-| pms.securityContext | object | `{}` | Security context for PMS pods |
+| pms.securityContext | object | `{}` | Security context applied to the PMS *container*. Use this for container-level fields such as `privileged`, `capabilities`, `readOnlyRootFilesystem` and `allowPrivilegeEscalation`. |
 | pms.shareProcessNamespace | bool | `false` | Enable process namespace sharing within the pod. |
 | pms.storageClassName | string | `nil` | The storage class to use when provisioning the pms config volume this needs to be created manually, null will use the default |
 | priorityClassName | string | `""` |  |

--- a/charts/plex-media-server/templates/statefulset.yaml
+++ b/charts/plex-media-server/templates/statefulset.yaml
@@ -36,6 +36,10 @@ spec:
       runtimeClassName: {{ .Values.runtimeClassName | quote }}
       {{- end }}
       serviceAccountName: {{ include "pms-chart.serviceAccountName" . }}
+      {{- with .Values.pms.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- if .Values.pms.shareProcessNamespace }}
       shareProcessNamespace: {{ .Values.pms.shareProcessNamespace }}
       {{- end }}

--- a/charts/plex-media-server/values.yaml
+++ b/charts/plex-media-server/values.yaml
@@ -111,7 +111,13 @@ pms:
   #   cpu: 100m
   #   memory: 128Mi
 
-  # -- Security context for PMS pods
+  # -- Security context applied to the PMS *pod*. Use this for pod-level fields
+  # such as `fsGroup`, `supplementalGroups` and `fsGroupChangePolicy`.
+  podSecurityContext: {}
+
+  # -- Security context applied to the PMS *container*. Use this for
+  # container-level fields such as `privileged`, `capabilities`,
+  # `readOnlyRootFilesystem` and `allowPrivilegeEscalation`.
   securityContext: {}
 
   # -- Enable process namespace sharing within the pod.


### PR DESCRIPTION
`pms.securityContext` is documented as "Security context for PMS pods", but it renders into the container's securityContext, and the chart has no pod-level securityContext hook at all.

That mismatch silently discards pod-only fields. Setting `fsGroup` -- the documented way to make the config volume group-writable -- produces a manifest where `fsGroup` sits in a container securityContext, which the API server drops. The chart installs cleanly and the setting simply never takes effect.

Add `pms.podSecurityContext`, rendered on the pod spec, and correct both doc strings to say which level they apply to.

Backward compatible: `pms.securityContext` keeps rendering exactly where it did, and the new value defaults to `{}`, which emits nothing.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>