### PR TITLE
fix: compare PLEX_UPDATE_CHANNEL numerically

### DIFF
--- a/root/etc/cont-init.d/40-plex-first-run
+++ b/root/etc/cont-init.d/40-plex-first-run
@@ -101,7 +101,7 @@ fi
 # Get server token and only turn claim token into server token if we have former but not latter.
 token="$(getPref "PlexOnlineToken")"
 if [ -z "${PLEX_CLAIM}" ] && [ -f "${PLEX_CLAIM_FILE}" ]; then
-  PLEX_CLAIM=$(cat ${PLEX_CLAIM_FILE})
+  PLEX_CLAIM=$(cat "${PLEX_CLAIM_FILE}")
 fi
 if [ ! -z "${PLEX_CLAIM}" ] && [ -z "${token}" ]; then
   echo "Attempting to obtain server token from claim token"

--- a/root/plex-common.sh
+++ b/root/plex-common.sh
@@ -28,7 +28,7 @@ function getVersionInfo {
 
   local channel
   local tokenNeeded=1
-  if [ ! -z "${PLEX_UPDATE_CHANNEL}" ] && [ "${PLEX_UPDATE_CHANNEL}" > 0 ]; then
+  if [ -n "${PLEX_UPDATE_CHANNEL}" ] && [ "${PLEX_UPDATE_CHANNEL}" -gt 0 ] 2>/dev/null; then
     channel="${PLEX_UPDATE_CHANNEL}"
   elif [ "${version,,}" = "beta" ]; then
     channel=8


### PR DESCRIPTION
## Summary

`[ "${PLEX_UPDATE_CHANNEL}" > 0 ]` is a redirect, not a comparison. When the variable is set it created a file named `0` in the working directory and treated any non-empty value as true.

Use a numeric `-gt` test (non-numeric values fail closed) and quote `PLEX_CLAIM_FILE` when reading the claim token.

## Test plan

- [x] `bash -n root/plex-common.sh root/etc/cont-init.d/40-plex-first-run`
- [x] Reproduced the old `[ > 0 ]` creating a file named `0`
- [x] New `-gt` accepts `16`, rejects `0`, fails closed on non-numeric, and does not create `0`
- [x] `PLEX_CLAIM_FILE` is quoted